### PR TITLE
chore(docker): fix layer ordering, add .dockerignore, drop stdlib asy…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+data/
+config/config-local.json
+__pycache__
+*.pyc
+*.pyo
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
-# Use the Python slim image
-FROM python:3.12-slim
+FROM python:3.12.7-slim
 
 WORKDIR /app
 
-# Copy the application code
-COPY . .
-
-# Create the data folder
-RUN mkdir -p /app/data
-
-# Install system dependencies (including Chrome)
+# Install system dependencies and create non-root user in one layer
 RUN apt-get update && apt-get install -y \
     ffmpeg libsndfile1 curl chromium chromium-driver \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m botuser
 
-# Set environment variable for Chrome
-ENV PATH="/usr/bin:$PATH"
-
-# Install Python dependencies
+# Install Python dependencies (cached unless requirements.txt changes)
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Command to run your application
+# Copy application code
+COPY . .
+
+# Ensure data dir exists and is owned by the non-root user
+RUN mkdir -p /app/data && chown -R botuser:botuser /app
+
+USER botuser
+
 CMD ["python", "bot.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ scikit-learn~=1.5.2
 fuzzywuzzy~=0.18.0
 ffmpeg-python
 PyNaCl~=1.5.0
-asyncio~=3.4.3
 opentelemetry-api~=1.38.0
 opentelemetry-sdk~=1.38.0
 opentelemetry-instrumentation


### PR DESCRIPTION
…ncio dep

- Reorder Dockerfile layers so apt and pip caches survive code-only changes
- Pin base image to python:3.12.7-slim for reproducible builds
- Add non-root user (botuser) for security
- Remove redundant ENV PATH=/usr/bin line
- Add .dockerignore to exclude .git, data/, config-local.json, and bytecode
- Remove asyncio from requirements.txt (stdlib since Python 3.4)