### PR TITLE
fix(docker): use docker compose v2 plugin instead of docker-compose

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         stage('Deploy') {
             steps {
                 echo "Deploying with docker-compose..."
-                sh 'docker-compose up --build -d'
+                sh 'docker compose up --build -d'
             }
         }
 


### PR DESCRIPTION
docker-compose (v1 standalone) is not installed on the Jenkins host. Replace with the v2 plugin syntax: docker compose.