### PR TITLE
fix(docker): split compose build and up for older plugin compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         stage('Deploy') {
             steps {
                 echo "Deploying with docker-compose..."
-                sh 'docker compose up --build -d'
+                sh 'docker compose build && docker compose up -d'
             }
         }
 


### PR DESCRIPTION
docker compose up --build is not supported on this Docker version. Split into docker compose build && docker compose up -d instead.