### PR TITLE
fix(docker): remove env_file from compose, token comes from config.json

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ services:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql://botuser:botpassword@db:5432/discordbot
-    env_file:
-      - .env
     volumes:
       - ${DISCORD_DATA_PATH:-./data}:/app/data
       - ${DISCORD_DATA_PATH:-./config}/config.json:/app/config/config.json


### PR DESCRIPTION
Discord token is already provided via the config.json volume mount. The env_file .env was unnecessary and caused a startup failure on the Jenkins host where that file does not exist.