### PR TITLE
feat(feed): migrate rss_data.json to PostgreSQL

### DIFF
--- a/functions/feed.py
+++ b/functions/feed.py
@@ -2,166 +2,146 @@ from utils.utils import *
 from utils.config import *
 from utils.tracing import trace_function
 from functions.tasks import _run_new_episode_check_logic, announce_new_episode
+from utils.db import (
+    rss_get_series_list, rss_get_subscribed_series, rss_get_unsubscribed_series,
+    rss_get_all_with_subs, rss_add_feed, rss_delete_series,
+    rss_subscribe, rss_unsubscribe,
+)
 
-# Add rss to json file
+
 @trace_function
 async def add_rss(interaction: discord.Interaction, search):
-    rss_data = fetch_rss_feed()  # Fetch RSS feed
-    # Only sanitize the series name (not the entire dictionary)
-    sanitized_rss_data = [sanitize_option(entry['series']) for entry in rss_data]
-    sanitized_rss_data = list(set(sanitized_rss_data)) # removes dupes
-    # Get the list of existing series from the JSON file
-    existing_series = get_json_field_as_array(RSS_FILE_PATH, "series")
-    # Filter out series that are already in the JSON file
-    search          = search if search is not None else ""
-    filtered_series = [series for series in sanitized_rss_data if series not in existing_series and search.lower() in series.lower()]
+    rss_data = fetch_rss_feed()
+    sanitized_rss_data = list(set(sanitize_option(entry['series']) for entry in rss_data))
+    existing_series = await rss_get_series_list()
+    search = search if search is not None else ""
+    filtered_series = [
+        s for s in sanitized_rss_data
+        if s not in existing_series and search.lower() in s.lower()
+    ]
 
-    if len(filtered_series) == 0:
+    if not filtered_series:
         return await interaction.response.send_message("If you can't spell, DON'T :)")
 
-    initial_text = "Select a series to add to your feed (only one at a time):"
-    picked_option = await dropdown_interactions(interaction, filtered_series, initial_text)
+    picked_option = await dropdown_interactions(
+        interaction, filtered_series, "Select a series to add to your feed (only one at a time):"
+    )
 
     if picked_option:
-        selected_entry = next((entry for entry in rss_data if entry['series'] == picked_option), None)
+        selected_entry = next((e for e in rss_data if e['series'] == picked_option), None)
         if selected_entry:
-            # Subscribe the user to the RSS
             user = interaction.user
-            selected_entry["subs"].append(str(user.id))
-            # Add the selected full entry to the JSON file
-            json_data = load_json_data(RSS_FILE_PATH)
-            json_data.append(selected_entry)  # Append the entire entry
-            await announce_new_episode(selected_entry["title"], selected_entry["link"], selected_entry["subs"], bot)
-            save_json_data(RSS_FILE_PATH, json_data)
-            return await interaction.followup.send(f'Series "{picked_option}" has been added to the feed!') 
+            await rss_add_feed(selected_entry, user_id=user.id)
+            await announce_new_episode(selected_entry["title"], selected_entry["link"], [str(user.id)], bot)
+            return await interaction.followup.send(f'Series "{picked_option}" has been added to the feed!')
         else:
             return await interaction.followup.send(f'Could not find data for the series "{picked_option}".')
-        
-# View current rss feeds
+
+
 @trace_function
 async def view_rss(interaction: discord.Interaction, search):
     user = interaction.user
-    rss_data = load_json_data(RSS_FILE_PATH)
-    
-    if not rss_data:
+    all_series = await rss_get_series_list()
+
+    if not all_series:
         await interaction.response.send_message("Your RSS feed is empty.")
         return
-    
-    # Filter series into subscribed and not subscribed
-    subscribed = [item["series"] for item in rss_data if str(user.id) in item["subs"]]
-    not_subscribed = [item["series"] for item in rss_data if str(user.id) not in item["subs"]]
-    
+
+    subscribed = await rss_get_subscribed_series(user.id)
+    subscribed_set = set(subscribed)
+    not_subscribed = [s for s in all_series if s not in subscribed_set]
+
     message = "**Your RSS Feed:**\n```\n"
-    
     if subscribed:
-        message += "SUBSCRIBED:\n"
-        message += "\n".join(subscribed)
-    
+        message += "SUBSCRIBED:\n" + "\n".join(subscribed)
     if not_subscribed:
-        if subscribed:
-            message += "\n\nNOT SUBSCRIBED:\n"
-        else:
-            message += "NOT SUBSCRIBED:\n"
+        message += ("\n\nNOT SUBSCRIBED:\n" if subscribed else "NOT SUBSCRIBED:\n")
         message += "\n".join(not_subscribed)
-    
     message += "\n```"
     await interaction.response.send_message(message)
 
-# Remove a series from the JSON file
-@trace_function
-def remove_series(series_to_remove):
-    json_data = load_json_data(RSS_FILE_PATH)
-    # Remove all items where the series matches the one to delete
-    updated_data = [item for item in json_data if item["series"] != series_to_remove]
-    save_json_data(RSS_FILE_PATH, updated_data)
 
-# Remove a series from the JSON file
 @trace_function
 async def remove_rss(interaction: discord.Interaction, search):
-    series_list = get_json_field_as_array(RSS_FILE_PATH, "series")
+    series_list = await rss_get_series_list()
     if not series_list:
         return await interaction.response.send_message("No series found to remove.", ephemeral=True)
-        
-    initial_text = "Select an episode to remove from your feed:"
-    picked_option = await dropdown_interactions(interaction, series_list, initial_text)
+
+    picked_option = await dropdown_interactions(
+        interaction, series_list, "Select an episode to remove from your feed:"
+    )
 
     if picked_option:
-        remove_series(picked_option)
+        await rss_delete_series(picked_option)
         await interaction.followup.send(f"The series **{picked_option}** has been removed successfully.")
+
 
 @trace_function
 async def sub_to_rss(interaction: discord.Interaction, search):
-    user        = interaction.user
-    rss_data    = load_json_data(RSS_FILE_PATH)
-    series_list = get_json_field_as_array(RSS_FILE_PATH, "series")
+    user = interaction.user
+    all_series = await rss_get_series_list()
 
-    if not series_list:
+    if not all_series:
         return await interaction.response.send_message("No series found to subscribe to :<", ephemeral=True)
-    
-    # Filter to only series the user is NOT subscribed to
-    available_series = [item["series"] for item in rss_data if str(user.id) not in item["subs"]]
-    
+
+    available_series = await rss_get_unsubscribed_series(user.id)
+
     if not available_series:
         return await interaction.response.send_message("You are already subscribed to all series!", ephemeral=True)
-    
-    initial_text = "Select a series to subscribe to:"
-    picked_option = await dropdown_interactions(interaction, available_series, initial_text)
+
+    picked_option = await dropdown_interactions(
+        interaction, available_series, "Select a series to subscribe to:"
+    )
 
     if picked_option:
-        for item in rss_data:
-            if item["series"] == picked_option and str(user.id) not in item["subs"]:
-                item["subs"].append(str(user.id))  # Update the subs array
-                save_json_data(RSS_FILE_PATH,rss_data)
-                return await interaction.followup.send(f"Successfully subscribed {user.mention} to {picked_option} RSS feed!") 
-    
+        subscribed = await rss_subscribe(picked_option, user.id)
+        if subscribed:
+            return await interaction.followup.send(
+                f"Successfully subscribed {user.mention} to {picked_option} RSS feed!"
+            )
     return await interaction.followup.send(f"Already subscribed to {picked_option} RSS feed!")
+
 
 @trace_function
 async def unsub_from_rss(interaction: discord.Interaction, search):
-    user        = interaction.user
-    rss_data    = load_json_data(RSS_FILE_PATH)
-    series_list = get_json_field_as_array(RSS_FILE_PATH, "series")
+    user = interaction.user
+    subscribed_series = await rss_get_subscribed_series(user.id)
 
-    if not series_list:
-        return await interaction.response.send_message("No series found to unsub from :<.", ephemeral=True)
-    
-    # Filter to only series the user IS subscribed to
-    subscribed_series = [item["series"] for item in rss_data if str(user.id) in item["subs"]]
-    
     if not subscribed_series:
-        return await interaction.response.send_message("You are not subscribed to any series!", ephemeral=True)
-    
-    initial_text = "Select a series to unsubscribe from:"
-    picked_option = await dropdown_interactions(interaction, subscribed_series, initial_text)
+        return await interaction.response.send_message(
+            "You are not subscribed to any series!", ephemeral=True
+        )
+
+    picked_option = await dropdown_interactions(
+        interaction, subscribed_series, "Select a series to unsubscribe from:"
+    )
 
     if picked_option:
-        # Modify the subs array if series matches
-        for item in rss_data:
-            if item["series"] == picked_option and str(user.id) in item["subs"]:
-                item["subs"].remove(str(user.id))
-                save_json_data(RSS_FILE_PATH,rss_data)
-                return await interaction.followup.send(f"Successfully removed {user.mention} from {picked_option} RSS feed :( but why?")
-    
+        unsubbed = await rss_unsubscribe(picked_option, user.id)
+        if unsubbed:
+            return await interaction.followup.send(
+                f"Successfully removed {user.mention} from {picked_option} RSS feed :( but why?"
+            )
     return await interaction.followup.send(f"Already unsubscribed from {picked_option}")
 
-# View all rss subscriptions
+
 @trace_function
 async def all_rss_subscribe(interaction: discord.Interaction, search):
-    rss_data = load_json_data(RSS_FILE_PATH)
-    
-    if not rss_data:
+    feeds = await rss_get_all_with_subs()
+
+    if not feeds:
         await interaction.response.send_message("No RSS data found.")
         return
 
     await interaction.response.defer()
-    
+
     message = "**All RSS Subscriptions:**\n"
     has_subs = False
-    
-    for entry in rss_data:
-        series = entry.get("series")
-        subs = entry.get("subs", [])
-        
+
+    for entry in feeds:
+        series = entry["series"]
+        subs = entry["subs"]
+
         if subs:
             has_subs = True
             message += f"\n**{series}**:\n"
@@ -170,24 +150,26 @@ async def all_rss_subscribe(interaction: discord.Interaction, search):
                     user = interaction.guild.get_member(int(sub_id))
                     if not user:
                         user = await interaction.client.fetch_user(int(sub_id))
-                    
                     user_name = user.display_name if user else f"Unknown User ({sub_id})"
                     message += f"- {user_name}\n"
                 except Exception:
                     message += f"- Unknown User ({sub_id})\n"
 
     if not has_subs:
-         await interaction.followup.send("No subscriptions found.")
-         return
+        await interaction.followup.send("No subscriptions found.")
+        return
 
     if len(message) > 2000:
-        # Create a text file if message is too long
         with io.BytesIO() as file_buffer:
             file_buffer.write(message.encode('utf-8'))
             file_buffer.seek(0)
-            await interaction.followup.send("The list is too long, here is a file:", file=discord.File(file_buffer, "subscriptions.txt"))
+            await interaction.followup.send(
+                "The list is too long, here is a file:",
+                file=discord.File(file_buffer, "subscriptions.txt"),
+            )
     else:
         await interaction.followup.send(message)
+
 
 @trace_function
 async def check_rss_feed_command(interaction: discord.Interaction):
@@ -195,16 +177,17 @@ async def check_rss_feed_command(interaction: discord.Interaction):
     await _run_new_episode_check_logic(interaction.client)
     await interaction.followup.send("RSS feed check initiated and completed!", ephemeral=True)
 
+
 @trace_function
 async def rss_menu(interaction: discord.Interaction, action, search):
     action_map = {
-        "add_rss": add_rss,
-        "view_rss": view_rss,
-        "remove_rss": remove_rss,
-        "sub_to_rss": sub_to_rss,
-        "unsub_from_rss": unsub_from_rss,
+        "add_rss":           add_rss,
+        "view_rss":          view_rss,
+        "remove_rss":        remove_rss,
+        "sub_to_rss":        sub_to_rss,
+        "unsub_from_rss":    unsub_from_rss,
         "all_rss_subscribe": all_rss_subscribe,
-        "check_rss": check_rss_feed_command,
+        "check_rss":         check_rss_feed_command,
     }
     action_func = action_map.get(action.value)
 

--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -1,6 +1,7 @@
 import requests
 from utils.utils import *
 from utils.tracing import trace_function
+from utils.db import rss_get_all_episodes, rss_update_episode, rss_add_feed, rss_get_series_list
 from fuzzywuzzy import fuzz
 from datetime import datetime
 from discord.ext import tasks
@@ -48,34 +49,27 @@ async def announce_new_episode(title, magnet_link, subs, bot):
 @trace_function
 async def check_for_new_episodes(bot):
     botLogger.info('searching for new episodes from the RSS feed')
-    feed_entries = fetch_rss_feed()  # RSS feed entries from URL
-    saved_entries = load_json_data(RSS_FILE_PATH)  # Current subscriptions from the JSON file
+    feed_entries = fetch_rss_feed()
+    saved_entries = await rss_get_all_episodes()
 
-    # Iterate through each feed entry and compare it with saved entries
     for feed_entry in feed_entries:
-        # Find the corresponding saved entry by series name
         matching_entry = next(
             (entry for entry in saved_entries if entry["series"] == feed_entry["series"]), None
         )
         if matching_entry:
-            # If the saved entry exists, compare the pubDate to see if it has been updated
             saved_pub_date = parse_pub_date(matching_entry["pubDate"])
             new_pub_date = parse_pub_date(feed_entry["pubDate"])
 
-            # If the pubDate is newer, update the saved entry
             if new_pub_date > saved_pub_date:
-                # Update the fields (you can add more fields as needed)
-                matching_entry["pubDate"]   = feed_entry["pubDate"]
-                matching_entry["title"]     = feed_entry["title"]
-                matching_entry["link"]      = feed_entry["link"]
-                matching_entry["size"]      = feed_entry["size"]
+                await rss_update_episode(
+                    feed_entry["series"],
+                    feed_entry["pubDate"],
+                    feed_entry["title"],
+                    feed_entry["link"],
+                    feed_entry["size"],
+                )
+                await announce_new_episode(feed_entry["title"], feed_entry["link"], matching_entry["subs"], bot)
 
-                await announce_new_episode(matching_entry["title"], matching_entry["link"], matching_entry["subs"], bot)
-    
-    botLogger.info('finished searching for new episodes from the RSS feed')
-
-    # Save the updated subscriptions back to the JSON file
-    save_json_data(RSS_FILE_PATH, saved_entries)
     botLogger.info('rss_check_complete')
 
 # The actual task loop
@@ -91,7 +85,7 @@ async def check_for_new_anime(bot):
     update_anime_list_by_status(Statuses.CURRENTLY_WATCHING.value)
 
     rss_data = fetch_rss_feed()
-    existing_series = get_json_field_as_array(RSS_FILE_PATH, "series")
+    existing_series = await rss_get_series_list()
     feed_names = list(map(lambda x: x["series"], rss_data))
     filtered_series = [series for series in feed_names if series not in existing_series]
     filtered_series = list(map(lambda x: x.strip().lower(), filtered_series))
@@ -108,11 +102,7 @@ async def check_for_new_anime(bot):
     for anime in similarity_list:
         selected_entry = next((entry for entry in rss_data if entry['series'].strip().lower() == anime), None)
         if selected_entry:
-            # Add the selected full entry to the JSON file
-            json_data = load_json_data(RSS_FILE_PATH)
-            json_data.append(selected_entry)  # Append the entire entry
-            save_json_data(RSS_FILE_PATH, json_data)
-
+            await rss_add_feed(selected_entry)
             await channel.send('I find a treasure: ' + selected_entry['series'] +' ,I added this to the RSS for you ;)')
 
     botLogger.info('anime_check_complete')

--- a/utils/db.py
+++ b/utils/db.py
@@ -46,8 +46,31 @@ async def ensure_schema() -> None:
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """)
-    botLogger.info("roulette_options table ensured")
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS rss_feeds (
+                id         SERIAL      PRIMARY KEY,
+                series     TEXT        NOT NULL UNIQUE,
+                title      TEXT        NOT NULL,
+                link       TEXT        NOT NULL,
+                guid       TEXT,
+                pub_date   TEXT        NOT NULL,
+                size       TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS rss_subscriptions (
+                feed_id    INTEGER     NOT NULL REFERENCES rss_feeds(id) ON DELETE CASCADE,
+                user_id    BIGINT      NOT NULL,
+                PRIMARY KEY (feed_id, user_id)
+            )
+        """)
+    botLogger.info("schema ensured")
 
+
+# ---------------------------------------------------------------------------
+# Roulette helpers
+# ---------------------------------------------------------------------------
 
 @trace_function
 async def roulette_load_all() -> list[str]:
@@ -84,4 +107,172 @@ async def roulette_remove(line: str) -> None:
         await conn.execute(
             "DELETE FROM roulette_options WHERE line = $1",
             line,
+        )
+
+
+# ---------------------------------------------------------------------------
+# RSS helpers
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def rss_get_series_list() -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT series FROM rss_feeds ORDER BY created_at ASC"
+        )
+    return [row["series"] for row in rows]
+
+
+@trace_function
+async def rss_get_subscribed_series(user_id: int) -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT f.series FROM rss_feeds f
+            JOIN rss_subscriptions s ON f.id = s.feed_id
+            WHERE s.user_id = $1
+            ORDER BY f.created_at ASC
+            """,
+            user_id,
+        )
+    return [row["series"] for row in rows]
+
+
+@trace_function
+async def rss_get_unsubscribed_series(user_id: int) -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT f.series FROM rss_feeds f
+            WHERE NOT EXISTS (
+                SELECT 1 FROM rss_subscriptions s
+                WHERE s.feed_id = f.id AND s.user_id = $1
+            )
+            ORDER BY f.created_at ASC
+            """,
+            user_id,
+        )
+    return [row["series"] for row in rows]
+
+
+@trace_function
+async def rss_get_all_with_subs() -> list[dict]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT f.series,
+                   COALESCE(array_agg(s.user_id) FILTER (WHERE s.user_id IS NOT NULL), '{}') AS subs
+            FROM rss_feeds f
+            LEFT JOIN rss_subscriptions s ON f.id = s.feed_id
+            GROUP BY f.id, f.series
+            ORDER BY f.created_at ASC
+            """
+        )
+    return [{"series": row["series"], "subs": list(row["subs"])} for row in rows]
+
+
+@trace_function
+async def rss_get_all_episodes() -> list[dict]:
+    """Return all feeds with subscriber lists for episode checking."""
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT f.series, f.title, f.link, f.pub_date, f.size,
+                   COALESCE(array_agg(s.user_id) FILTER (WHERE s.user_id IS NOT NULL), '{}') AS subs
+            FROM rss_feeds f
+            LEFT JOIN rss_subscriptions s ON f.id = s.feed_id
+            GROUP BY f.id
+            ORDER BY f.created_at ASC
+            """
+        )
+    return [
+        {
+            "series":  row["series"],
+            "title":   row["title"],
+            "link":    row["link"],
+            "pubDate": row["pub_date"],
+            "size":    row["size"],
+            "subs":    [str(uid) for uid in row["subs"]],
+        }
+        for row in rows
+    ]
+
+
+@trace_function
+async def rss_add_feed(entry: dict, user_id: int | None = None) -> None:
+    """Insert a feed entry, optionally subscribing a user. No-op if series exists."""
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO rss_feeds (series, title, link, guid, pub_date, size)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (series) DO NOTHING
+            RETURNING id
+            """,
+            entry["series"],
+            entry["title"],
+            entry["link"],
+            entry.get("guid"),
+            entry["pubDate"],
+            entry.get("size"),
+        )
+        if row and user_id is not None:
+            await conn.execute(
+                """
+                INSERT INTO rss_subscriptions (feed_id, user_id)
+                VALUES ($1, $2)
+                ON CONFLICT DO NOTHING
+                """,
+                row["id"],
+                user_id,
+            )
+
+
+@trace_function
+async def rss_delete_series(series: str) -> None:
+    async with get_pool().acquire() as conn:
+        await conn.execute("DELETE FROM rss_feeds WHERE series = $1", series)
+
+
+@trace_function
+async def rss_subscribe(series: str, user_id: int) -> bool:
+    """Returns True if newly subscribed, False if already subscribed."""
+    async with get_pool().acquire() as conn:
+        result = await conn.execute(
+            """
+            INSERT INTO rss_subscriptions (feed_id, user_id)
+            SELECT id, $2 FROM rss_feeds WHERE series = $1
+            ON CONFLICT DO NOTHING
+            """,
+            series,
+            user_id,
+        )
+    return result.endswith("1")
+
+
+@trace_function
+async def rss_unsubscribe(series: str, user_id: int) -> bool:
+    """Returns True if unsubscribed, False if wasn't subscribed."""
+    async with get_pool().acquire() as conn:
+        result = await conn.execute(
+            """
+            DELETE FROM rss_subscriptions
+            WHERE feed_id = (SELECT id FROM rss_feeds WHERE series = $1)
+            AND user_id = $2
+            """,
+            series,
+            user_id,
+        )
+    return result.endswith("1")
+
+
+@trace_function
+async def rss_update_episode(series: str, pub_date: str, title: str, link: str, size: str) -> None:
+    async with get_pool().acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE rss_feeds SET pub_date = $1, title = $2, link = $3, size = $4
+            WHERE series = $5
+            """,
+            pub_date, title, link, size, series,
         )


### PR DESCRIPTION
Add rss_feeds and rss_subscriptions tables to ensure_schema. Add RSS CRUD helpers to utils/db.py: rss_get_series_list, rss_get_subscribed_series, rss_get_unsubscribed_series, rss_get_all_with_subs, rss_get_all_episodes, rss_add_feed, rss_delete_series, rss_subscribe, rss_unsubscribe, rss_update_episode.

Rewrite feed.py to use DB helpers instead of load/save_json_data. Rewrite check_for_new_episodes and check_for_new_anime in tasks.py to read/write via DB. The subs junction table replaces the inline subs array, and ON DELETE CASCADE keeps subscriptions consistent when a series is removed.