### PR TITLE
feat(mal): migrate mal_profile.txt and anime_list to PostgreSQL

### DIFF
--- a/functions/mal.py
+++ b/functions/mal.py
@@ -3,6 +3,7 @@ from functions.roulettes import roulette
 from functions.roulettes import roulette
 from utils.utils import *
 from utils.tracing import trace_function
+from utils.db import mal_get_users, mal_add_user, mal_remove_user, anime_list_get
 
 
 @trace_function
@@ -31,29 +32,23 @@ async def anime_list_menu(bot, interaction: discord.Interaction, action, user: s
 
 @trace_function
 async def next_anime(interaction: discord.Interaction):
-    file_address = MAL_STATUSES_FORMAT.format(Statuses.PLAN_TO_WATCH.value)
-
-    anime_list = load_text_data(file_address)
+    anime_list = await anime_list_get(Statuses.PLAN_TO_WATCH.value)
     anime_roulete_string = ",".join(anime_list)
     await roulette(interaction, anime_roulete_string)
 
 @trace_function
 async def add_users_mal(interaction, user: str):
-    lines = load_text_data(MAL_PROFILE_PATH)
-    lines.append(user.strip())
-    save_text_data(MAL_PROFILE_PATH, lines)
+    await mal_add_user(user.strip())
     await interaction.response.send_message(f"Added the new user: {user.strip()}")
 
 @trace_function
 async def view_users_mal(interaction):
-    lines = load_text_data(MAL_PROFILE_PATH)
+    lines = await mal_get_users()
     await interaction.response.send_message(f"Users: {', '.join(lines)}")
 
 @trace_function
 async def remove_users_mal(interaction, user: str):
-    lines = load_text_data(MAL_PROFILE_PATH)
-    lines.remove(user.strip())
-    save_text_data(MAL_PROFILE_PATH, lines)
+    await mal_remove_user(user.strip())
     await interaction.response.send_message(f"Removed the new option set: {user.strip()}")
 
 @trace_function
@@ -61,20 +56,15 @@ async def update_anime_list(bot, interaction, status):
     await interaction.response.send_message(f"Will be updated.")
 
     channel = bot.get_channel(BOT_CHANNEL_ID)
-    name    = update_anime_list_by_status(status)
+    name    = await update_anime_list_by_status(status)
 
     await channel.send(f"Finish to update {name} list.")
 
 
 @trace_function
 async def view_anime_list(interaction, status):
-    file_address = MAL_STATUSES_FORMAT.format(status)
-
-    anime_list = load_text_data(file_address)
+    anime_list = await anime_list_get(status)
     if len(anime_list) > 0:
         await interaction.response.send_message("\n".join(anime_list)[:MAX_LETTERS])
     else:
         await interaction.response.send_message("No anime.")
-
-
-

--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -82,7 +82,7 @@ async def _run_new_episode_check_logic(bot):
 @trace_function
 async def check_for_new_anime(bot):
     channel = bot.get_channel(BOT_CHANNEL_ID)
-    update_anime_list_by_status(Statuses.CURRENTLY_WATCHING.value)
+    await update_anime_list_by_status(Statuses.CURRENTLY_WATCHING.value)
 
     rss_data = fetch_rss_feed()
     existing_series = await rss_get_series_list()

--- a/utils/db.py
+++ b/utils/db.py
@@ -65,6 +65,21 @@ async def ensure_schema() -> None:
                 PRIMARY KEY (feed_id, user_id)
             )
         """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS mal_profiles (
+                id         SERIAL      PRIMARY KEY,
+                username   TEXT        NOT NULL UNIQUE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS anime_list (
+                id         SERIAL      PRIMARY KEY,
+                status     INTEGER     NOT NULL,
+                title      TEXT        NOT NULL,
+                UNIQUE (status, title)
+            )
+        """)
     botLogger.info("schema ensured")
 
 
@@ -276,3 +291,55 @@ async def rss_update_episode(series: str, pub_date: str, title: str, link: str, 
             """,
             pub_date, title, link, size, series,
         )
+
+
+# ---------------------------------------------------------------------------
+# MAL profile helpers
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def mal_get_users() -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch("SELECT username FROM mal_profiles ORDER BY created_at ASC")
+    return [row["username"] for row in rows]
+
+
+@trace_function
+async def mal_add_user(username: str) -> None:
+    async with get_pool().acquire() as conn:
+        await conn.execute(
+            "INSERT INTO mal_profiles (username) VALUES ($1) ON CONFLICT (username) DO NOTHING",
+            username,
+        )
+
+
+@trace_function
+async def mal_remove_user(username: str) -> None:
+    async with get_pool().acquire() as conn:
+        await conn.execute("DELETE FROM mal_profiles WHERE username = $1", username)
+
+
+# ---------------------------------------------------------------------------
+# Anime list helpers
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def anime_list_get(status: int) -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT title FROM anime_list WHERE status = $1 ORDER BY id ASC", status
+        )
+    return [row["title"] for row in rows]
+
+
+@trace_function
+async def anime_list_replace(status: int, titles: list[str]) -> None:
+    """Atomically replace all titles for a given status."""
+    async with get_pool().acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("DELETE FROM anime_list WHERE status = $1", status)
+            if titles:
+                await conn.executemany(
+                    "INSERT INTO anime_list (status, title) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                    [(status, t) for t in titles],
+                )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -202,20 +202,18 @@ def scrape_mal(user, status):
 
 
 @trace_function
-def update_anime_list_by_status(status):
-    file_address = MAL_STATUSES_FORMAT.format(status)
+async def update_anime_list_by_status(status):
+    from utils.db import mal_get_users, anime_list_replace
 
-    users = load_text_data(MAL_PROFILE_PATH)
+    users = await mal_get_users()
     titles = []
 
     for user in users:
         titles.extend(scrape_mal(user, status))
 
-    save_text_data(file_address, titles)
+    await anime_list_replace(status, titles)
 
-    name = Statuses(status).name
-
-    return name
+    return Statuses(status).name
 # endregion
 
 # region Roulette


### PR DESCRIPTION
Add mal_profiles and anime_list tables to ensure_schema. Add five DB helpers: mal_get_users, mal_add_user, mal_remove_user, anime_list_get, anime_list_replace (atomic delete+insert in a transaction).

Make update_anime_list_by_status async so it can await the DB calls. Update all callers in mal.py and tasks.py with await. Replace load/save_text_data calls in mal.py with DB helpers.