### PR TITLE
fix(mal): replace executemany with unnest bulk insert in anime_list_r…

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -339,7 +339,12 @@ async def anime_list_replace(status: int, titles: list[str]) -> None:
         async with conn.transaction():
             await conn.execute("DELETE FROM anime_list WHERE status = $1", status)
             if titles:
-                await conn.executemany(
-                    "INSERT INTO anime_list (status, title) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-                    [(status, t) for t in titles],
+                await conn.execute(
+                    """
+                    INSERT INTO anime_list (status, title)
+                    SELECT $1, t FROM unnest($2::text[]) AS t
+                    ON CONFLICT DO NOTHING
+                    """,
+                    status,
+                    titles,
                 )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -209,7 +209,9 @@ async def update_anime_list_by_status(status):
     titles = []
 
     for user in users:
-        titles.extend(scrape_mal(user, status))
+        user_titles = scrape_mal(user, status)
+        botLogger.info("scraped %d titles for %s (status=%s)", len(user_titles), user, status)
+        titles.extend(user_titles)
 
     await anime_list_replace(status, titles)
 


### PR DESCRIPTION
…eplace

asyncpg executemany uses internal pipelining which can silently abort mid-batch within a transaction. Replace with a single unnest-based INSERT that is definitively atomic. Add per-user title count logging to make scrape yield visible in logs.