### PR TITLE
chore(docker): add postgres-exporter for prometheus metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,19 @@ services:
       - default
       - monitoring
 
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.17.1
+    container_name: postgres-exporter
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATA_SOURCE_NAME: "postgresql://botuser:botpassword@db:5432/discordbot?sslmode=disable"
+    networks:
+      - default
+      - monitoring
+
 networks:
   monitoring:
     external: true


### PR DESCRIPTION
postgres-exporter joins both the default network (to reach the db service via internal hostname) and the external monitoring_monitoring network so prometheus can scrape it at postgres-exporter:9187.