### PR TITLE
feat(bot): unify command responses on discord embeds

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ from utils.config import config
 from utils.db import init_pool, ensure_schema
 from utils.logger import botLogger
 from utils.tracing import trace_function
+from utils.utils import make_embed
 
 # all discord user functions
 from functions.roulettes import roulette, auto_roulette_menu
@@ -101,11 +102,11 @@ async def on_app_command_error(interaction: discord.Interaction, error: app_comm
         "".join(traceback.format_exception(type(error), error, error.__traceback__)),
     )
     try:
-        msg = "An unexpected error occurred. The incident has been logged."
+        embed = make_embed("An unexpected error occurred. The incident has been logged.", kind="error")
         if interaction.response.is_done():
-            await interaction.followup.send(msg, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
         else:
-            await interaction.response.send_message(msg, ephemeral=True)
+            await interaction.response.send_message(embed=embed, ephemeral=True)
     except discord.HTTPException:
         pass
 

--- a/functions/feed.py
+++ b/functions/feed.py
@@ -21,7 +21,9 @@ async def add_rss(interaction: discord.Interaction, search):
     ]
 
     if not filtered_series:
-        return await interaction.response.send_message("If you can't spell, DON'T :)")
+        return await interaction.response.send_message(
+            embed=make_embed("If you can't spell, DON'T :)", kind="error")
+        )
 
     picked_option = await dropdown_interactions(
         interaction, filtered_series, "Select a series to add to your feed (only one at a time):"
@@ -33,9 +35,13 @@ async def add_rss(interaction: discord.Interaction, search):
             user = interaction.user
             await rss_add_feed(selected_entry, user_id=user.id)
             await announce_new_episode(selected_entry["title"], selected_entry["link"], [str(user.id)], interaction.client)
-            return await interaction.followup.send(f'Series "{picked_option}" has been added to the feed!')
+            return await interaction.followup.send(
+                embed=make_embed(f'Series "{picked_option}" has been added to the feed!', kind="success")
+            )
         else:
-            return await interaction.followup.send(f'Could not find data for the series "{picked_option}".')
+            return await interaction.followup.send(
+                embed=make_embed(f'Could not find data for the series "{picked_option}".', kind="error")
+            )
 
 
 @trace_function
@@ -44,28 +50,34 @@ async def view_rss(interaction: discord.Interaction, search):
     all_series = await rss_get_series_list()
 
     if not all_series:
-        await interaction.response.send_message("Your RSS feed is empty.")
+        await interaction.response.send_message(
+            embed=make_embed("Your RSS feed is empty.", kind="info")
+        )
         return
 
     subscribed = await rss_get_subscribed_series(user.id)
     subscribed_set = set(subscribed)
     not_subscribed = [s for s in all_series if s not in subscribed_set]
 
-    message = "**Your RSS Feed:**\n```\n"
+    message = "```\n"
     if subscribed:
         message += "SUBSCRIBED:\n" + "\n".join(subscribed)
     if not_subscribed:
         message += ("\n\nNOT SUBSCRIBED:\n" if subscribed else "NOT SUBSCRIBED:\n")
         message += "\n".join(not_subscribed)
     message += "\n```"
-    await interaction.response.send_message(message)
+    await interaction.response.send_message(
+        embed=make_embed(message, kind="info", title="Your RSS Feed")
+    )
 
 
 @trace_function
 async def remove_rss(interaction: discord.Interaction, search):
     series_list = await rss_get_series_list()
     if not series_list:
-        return await interaction.response.send_message("No series found to remove.", ephemeral=True)
+        return await interaction.response.send_message(
+            embed=make_embed("No series found to remove.", kind="warning"), ephemeral=True
+        )
 
     picked_option = await dropdown_interactions(
         interaction, series_list, "Select an episode to remove from your feed:"
@@ -73,7 +85,9 @@ async def remove_rss(interaction: discord.Interaction, search):
 
     if picked_option:
         await rss_delete_series(picked_option)
-        await interaction.followup.send(f"The series **{picked_option}** has been removed successfully.")
+        await interaction.followup.send(
+            embed=make_embed(f"The series **{picked_option}** has been removed successfully.", kind="success")
+        )
 
 
 @trace_function
@@ -82,12 +96,16 @@ async def sub_to_rss(interaction: discord.Interaction, search):
     all_series = await rss_get_series_list()
 
     if not all_series:
-        return await interaction.response.send_message("No series found to subscribe to :<", ephemeral=True)
+        return await interaction.response.send_message(
+            embed=make_embed("No series found to subscribe to :<", kind="warning"), ephemeral=True
+        )
 
     available_series = await rss_get_unsubscribed_series(user.id)
 
     if not available_series:
-        return await interaction.response.send_message("You are already subscribed to all series!", ephemeral=True)
+        return await interaction.response.send_message(
+            embed=make_embed("You are already subscribed to all series!", kind="info"), ephemeral=True
+        )
 
     picked_option = await dropdown_interactions(
         interaction, available_series, "Select a series to subscribe to:"
@@ -97,9 +115,14 @@ async def sub_to_rss(interaction: discord.Interaction, search):
         subscribed = await rss_subscribe(picked_option, user.id)
         if subscribed:
             return await interaction.followup.send(
-                f"Successfully subscribed {user.mention} to {picked_option} RSS feed!"
+                embed=make_embed(
+                    f"Successfully subscribed {user.mention} to {picked_option} RSS feed!",
+                    kind="success",
+                )
             )
-    return await interaction.followup.send(f"Already subscribed to {picked_option} RSS feed!")
+    return await interaction.followup.send(
+        embed=make_embed(f"Already subscribed to {picked_option} RSS feed!", kind="info")
+    )
 
 
 @trace_function
@@ -109,7 +132,7 @@ async def unsub_from_rss(interaction: discord.Interaction, search):
 
     if not subscribed_series:
         return await interaction.response.send_message(
-            "You are not subscribed to any series!", ephemeral=True
+            embed=make_embed("You are not subscribed to any series!", kind="info"), ephemeral=True
         )
 
     picked_option = await dropdown_interactions(
@@ -120,9 +143,14 @@ async def unsub_from_rss(interaction: discord.Interaction, search):
         unsubbed = await rss_unsubscribe(picked_option, user.id)
         if unsubbed:
             return await interaction.followup.send(
-                f"Successfully removed {user.mention} from {picked_option} RSS feed :( but why?"
+                embed=make_embed(
+                    f"Successfully removed {user.mention} from {picked_option} RSS feed :( but why?",
+                    kind="success",
+                )
             )
-    return await interaction.followup.send(f"Already unsubscribed from {picked_option}")
+    return await interaction.followup.send(
+        embed=make_embed(f"Already unsubscribed from {picked_option}", kind="info")
+    )
 
 
 @trace_function
@@ -130,12 +158,14 @@ async def all_rss_subscribe(interaction: discord.Interaction, search):
     feeds = await rss_get_all_with_subs()
 
     if not feeds:
-        await interaction.response.send_message("No RSS data found.")
+        await interaction.response.send_message(
+            embed=make_embed("No RSS data found.", kind="info")
+        )
         return
 
     await interaction.response.defer()
 
-    message = "**All RSS Subscriptions:**\n"
+    message = ""
     has_subs = False
 
     for entry in feeds:
@@ -156,26 +186,33 @@ async def all_rss_subscribe(interaction: discord.Interaction, search):
                     message += f"- Unknown User ({sub_id})\n"
 
     if not has_subs:
-        await interaction.followup.send("No subscriptions found.")
+        await interaction.followup.send(
+            embed=make_embed("No subscriptions found.", kind="info")
+        )
         return
 
-    if len(message) > 2000:
+    if len(message) > 4096:
         with io.BytesIO() as file_buffer:
             file_buffer.write(message.encode('utf-8'))
             file_buffer.seek(0)
             await interaction.followup.send(
-                "The list is too long, here is a file:",
+                embed=make_embed("The list is too long, here is a file:", kind="info"),
                 file=discord.File(file_buffer, "subscriptions.txt"),
             )
     else:
-        await interaction.followup.send(message)
+        await interaction.followup.send(
+            embed=make_embed(message, kind="info", title="All RSS Subscriptions")
+        )
 
 
 @trace_function
 async def check_rss_feed_command(interaction: discord.Interaction):
     await interaction.response.defer(ephemeral=True)
     await _run_new_episode_check_logic(interaction.client)
-    await interaction.followup.send("RSS feed check initiated and completed!", ephemeral=True)
+    await interaction.followup.send(
+        embed=make_embed("RSS feed check initiated and completed!", kind="success"),
+        ephemeral=True,
+    )
 
 
 @trace_function
@@ -197,4 +234,6 @@ async def rss_menu(interaction: discord.Interaction, action, search):
         else:
             await action_func(interaction, search)
     else:
-        await interaction.response.send_message("Invalid option selected.", ephemeral=True)
+        await interaction.response.send_message(
+            embed=make_embed("Invalid option selected.", kind="error"), ephemeral=True
+        )

--- a/functions/mal.py
+++ b/functions/mal.py
@@ -15,7 +15,9 @@ async def mal_menu(interaction: discord.Interaction, action, user: str = None):
     elif action.value == "remove_user":
         await remove_users_mal(interaction, user)
     else:
-        await interaction.response.send_message("Invalid option selected.", ephemeral=True)
+        await interaction.response.send_message(
+            embed=make_embed("Invalid option selected.", kind="error"), ephemeral=True
+        )
 
 @trace_function
 async def anime_list_menu(bot, interaction: discord.Interaction, action, user: str = None):
@@ -28,7 +30,9 @@ async def anime_list_menu(bot, interaction: discord.Interaction, action, user: s
     elif action.value == "view_plantowatch_list":
         await view_anime_list(interaction, Statuses.PLAN_TO_WATCH.value)
     else:
-        await interaction.response.send_message("Invalid option selected.", ephemeral=True)
+        await interaction.response.send_message(
+            embed=make_embed("Invalid option selected.", kind="error"), ephemeral=True
+        )
 
 @trace_function
 async def next_anime(interaction: discord.Interaction):
@@ -39,32 +43,46 @@ async def next_anime(interaction: discord.Interaction):
 @trace_function
 async def add_users_mal(interaction, user: str):
     await mal_add_user(user.strip())
-    await interaction.response.send_message(f"Added the new user: {user.strip()}")
+    await interaction.response.send_message(
+        embed=make_embed(f"Added the new user: {user.strip()}", kind="success")
+    )
 
 @trace_function
 async def view_users_mal(interaction):
     lines = await mal_get_users()
-    await interaction.response.send_message(f"Users: {', '.join(lines)}")
+    await interaction.response.send_message(
+        embed=make_embed(f"Users: {', '.join(lines)}", kind="info")
+    )
 
 @trace_function
 async def remove_users_mal(interaction, user: str):
     await mal_remove_user(user.strip())
-    await interaction.response.send_message(f"Removed the new option set: {user.strip()}")
+    await interaction.response.send_message(
+        embed=make_embed(f"Removed the new option set: {user.strip()}", kind="success")
+    )
 
 @trace_function
 async def update_anime_list(bot, interaction, status):
-    await interaction.response.send_message(f"Will be updated.")
+    await interaction.response.send_message(
+        embed=make_embed("Will be updated.", kind="info")
+    )
 
     channel = bot.get_channel(BOT_CHANNEL_ID)
     name    = await update_anime_list_by_status(status)
 
-    await channel.send(f"Finish to update {name} list.")
+    await channel.send(
+        embed=make_embed(f"Finish to update {name} list.", kind="success")
+    )
 
 
 @trace_function
 async def view_anime_list(interaction, status):
     anime_list = await anime_list_get(status)
     if len(anime_list) > 0:
-        await interaction.response.send_message("\n".join(anime_list)[:MAX_LETTERS])
+        await interaction.response.send_message(
+            embed=make_embed("\n".join(anime_list)[:MAX_LETTERS], kind="info")
+        )
     else:
-        await interaction.response.send_message("No anime.")
+        await interaction.response.send_message(
+            embed=make_embed("No anime.", kind="info")
+        )

--- a/functions/nyaa.py
+++ b/functions/nyaa.py
@@ -3,6 +3,7 @@ import aiohttp
 import discord
 from bs4 import BeautifulSoup
 from utils.tracing import trace_function
+from utils.utils import make_embed
 
 # nyaa search function - displays top 5 results from nyaa.si based on user query.
 @trace_function
@@ -18,22 +19,30 @@ async def search(interaction: discord.Interaction, query: str):
         async with aiohttp.ClientSession() as session:
             async with session.get(search_url, timeout=aiohttp.ClientTimeout(total=10)) as response:
                 if response.status != 200:
-                    await interaction.followup.send(f"❌ Failed to fetch results (HTTP {response.status})")
+                    await interaction.followup.send(
+                        embed=make_embed(f"❌ Failed to fetch results (HTTP {response.status})", kind="error")
+                    )
                     return
-                
+
                 html = await response.text()
     except asyncio.TimeoutError:
-        await interaction.followup.send("❌ Request timed out")
+        await interaction.followup.send(
+            embed=make_embed("❌ Request timed out", kind="error")
+        )
         return
     except Exception as e:
-        await interaction.followup.send(f"❌ Error fetching results: {str(e)}")
+        await interaction.followup.send(
+            embed=make_embed(f"❌ Error fetching results: {str(e)}", kind="error")
+        )
         return
             
     soup = BeautifulSoup(html, 'html.parser')
     rows = soup.select('table tr')[1:11]  # Skip header row, get next 10
     
     if not rows:
-        await interaction.followup.send("❌ No results found")
+        await interaction.followup.send(
+            embed=make_embed("❌ No results found", kind="error")
+        )
         return
         
     embed = discord.Embed(title=f"Nyaa Search Results for: {query}", 
@@ -88,7 +97,9 @@ async def search(interaction: discord.Interaction, query: str):
             continue
     
     if result_count == 0:
-        await interaction.followup.send("❌ No valid results found")
+        await interaction.followup.send(
+            embed=make_embed("❌ No valid results found", kind="error")
+        )
         return
     
     await interaction.followup.send(embed=embed)

--- a/functions/roulettes.py
+++ b/functions/roulettes.py
@@ -16,7 +16,9 @@ async def roulette(interaction: discord.Interaction, options: str):
             dict_options[name] = count
 
     if len(dict_options.keys()) < 1: # not a single valid choice in roulette
-        return await interaction.response.send_message("Insert at least one valid option..")
+        return await interaction.response.send_message(
+            embed=make_embed("Insert at least one valid option..", kind="error")
+        )
 
     winner = choose_winner(dict_options.items())
     if len(dict_options.keys()) < 7:
@@ -24,7 +26,9 @@ async def roulette(interaction: discord.Interaction, options: str):
         await interaction.response.send_message(embed=embed, file=file)
     else:
         await interaction.response.send_message(
-            f"The winner is:{winner[RouletteObject.name.value]}"
+            embed=make_embed(
+                f"The winner is:{winner[RouletteObject.name.value]}", kind="success"
+            )
         )
     return winner[RouletteObject.name.value]
 
@@ -45,7 +49,9 @@ def update_options(options, winner):
 async def auto_roulette(interaction: discord.Interaction):
     lines = await roulette_load_all()
     if not lines:
-        await interaction.response.send_message("No options are available. Please add some using `/roulette`.")
+        await interaction.response.send_message(
+            embed=make_embed("No options are available. Please add some using `/roulette`.", kind="info")
+        )
         return
 
     # Create dropdown menu options
@@ -63,20 +69,26 @@ async def auto_roulette(interaction: discord.Interaction):
         select_menu.callback = select_callback
         view.add_item(select_menu)
 
-    await interaction.response.send_message("Choose an option from the dropdown.", view=view)
+    await interaction.response.send_message(
+        embed=make_embed("Choose an option from the dropdown.", kind="info"), view=view
+    )
 
 @trace_function
 async def remove_auto_roulette(interaction: discord.Interaction):
     lines = await roulette_load_all()
     if not lines:
-        return await interaction.response.send_message("No options are available. Please add some using `/add_auto_roulette`.")
+        return await interaction.response.send_message(
+            embed=make_embed("No options are available. Please add some using `/add_auto_roulette`.", kind="info")
+        )
 
     # Create dropdown menu options
     select_menus = create_select_menus(lines)
     async def select_callback(interaction: discord.Interaction):
         selected_roulette = interaction.data['values'][0]
         await roulette_remove(selected_roulette)
-        return await interaction.response.send_message(f"Removed the option set: `{selected_roulette}`")
+        return await interaction.response.send_message(
+            embed=make_embed(f"Removed the option set: `{selected_roulette}`", kind="success")
+        )
 
      # Create a view for the select menus
     view = discord.ui.View()
@@ -84,14 +96,20 @@ async def remove_auto_roulette(interaction: discord.Interaction):
         select_menu.callback = select_callback
         view.add_item(select_menu)
 
-    return await interaction.response.send_message("Choose an option from the dropdown.", view=view)
+    return await interaction.response.send_message(
+        embed=make_embed("Choose an option from the dropdown.", kind="info"), view=view
+    )
 
 @trace_function
 async def add_auto_roulette(interaction: discord.Interaction, option_line: str):
     inserted = await roulette_add(option_line.strip())
     if not inserted:
-        return await interaction.response.send_message(f"The option set `{option_line.strip()}` already exists.")
-    return await interaction.response.send_message(f"Added the new option set: `{option_line.strip()}`")
+        return await interaction.response.send_message(
+            embed=make_embed(f"The option set `{option_line.strip()}` already exists.", kind="warning")
+        )
+    return await interaction.response.send_message(
+        embed=make_embed(f"Added the new option set: `{option_line.strip()}`", kind="success")
+    )
 
 @trace_function
 async def auto_roulette_menu(interaction: discord.Interaction, action, add_option):
@@ -99,10 +117,15 @@ async def auto_roulette_menu(interaction: discord.Interaction, action, add_optio
         await auto_roulette(interaction)
     elif action.value == "add_roulette":
         if add_option is None:
-            await interaction.response.send_message("Please provide a string for the new roulette option:", ephemeral=True)
+            await interaction.response.send_message(
+                embed=make_embed("Please provide a string for the new roulette option:", kind="info"),
+                ephemeral=True,
+            )
             return
         await add_auto_roulette(interaction, add_option)
     elif action.value == "remove_roulette":
         await remove_auto_roulette(interaction)
     else:
-        await interaction.response.send_message("Invalid option selected.", ephemeral=True)
+        await interaction.response.send_message(
+            embed=make_embed("Invalid option selected.", kind="error"), ephemeral=True
+        )

--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -30,18 +30,15 @@ async def announce_new_episode(title, magnet_link, subs, bot):
     # Check if the response contains the magnet entries
     if responseJson and "magnetEntries" in responseJson and responseJson["magnetEntries"]:
         magnet_url = responseJson["magnetEntries"][0]  # Get the first magnet URL
-        # Format the title as the clickable text and mention all subscribers
-        formatted_message = f"New Episode Available: [{title}]({magnet_url})\n"
-        # Mention all the users
+        # Mentions live in `content` so they actually ping subscribers; the embed is just the formatted link
         user_mentions = " ".join([f"<@{user_id}>" for user_id in subs])
-        # Add the mentions to the formatted message
-        formatted_message += f"\n{user_mentions}"
-        await channel.send(formatted_message)
+        embed = make_embed(f"New Episode Available: [{title}]({magnet_url})", kind="success")
+        await channel.send(content=user_mentions, embed=embed)
     else:
         # If no magnet URL is available or URL limit reached, log the error
         message = (responseJson or {}).get('message', 'tormag unreachable')
         formatted_message = (f"Error for {title}: {message} \nhere is the magnet instead :D : \n{magnet_link}")
-        await channel.send(formatted_message)
+        await channel.send(embed=make_embed(formatted_message, kind="error"))
     botLogger.info('finished announcing new episode')
 
 
@@ -103,7 +100,12 @@ async def check_for_new_anime(bot):
         selected_entry = next((entry for entry in rss_data if entry['series'].strip().lower() == anime), None)
         if selected_entry:
             await rss_add_feed(selected_entry)
-            await channel.send('I find a treasure: ' + selected_entry['series'] +' ,I added this to the RSS for you ;)')
+            await channel.send(
+                embed=make_embed(
+                    'I find a treasure: ' + selected_entry['series'] + ' ,I added this to the RSS for you ;)',
+                    kind="success",
+                )
+            )
 
     botLogger.info('anime_check_complete')
 

--- a/functions/voice.py
+++ b/functions/voice.py
@@ -3,6 +3,7 @@ import discord
 from discord import FFmpegPCMAudio
 from utils.logger import botLogger
 from utils.tracing import trace_function
+from utils.utils import make_embed
 
 
 async def _ensure_voice_client(guild, voice_channel):
@@ -25,13 +26,17 @@ async def play(interaction: discord.Interaction, query: str, bot):
 
     # Validate input
     if not query or query is None:
-        await interaction.followup.send("❌ Please provide a valid URL or search query.")
+        await interaction.followup.send(
+            embed=make_embed("❌ Please provide a valid URL or search query.", kind="error")
+        )
         return
 
     # Check if the user is in a voice channel
     voice_channel = interaction.user.voice.channel if interaction.user.voice else None
     if not voice_channel:
-        await interaction.followup.send("❌ You need to join a voice channel first!")
+        await interaction.followup.send(
+            embed=make_embed("❌ You need to join a voice channel first!", kind="error")
+        )
         return
 
     voice_client = await _ensure_voice_client(interaction.guild, voice_channel)
@@ -57,15 +62,19 @@ async def play(interaction: discord.Interaction, query: str, bot):
                 search_results = ydl.extract_info(f"ytsearch:{query}", download=False)
                 
                 if not search_results or 'entries' not in search_results or len(search_results['entries']) == 0:
-                    await interaction.followup.send("❌ No results found for that query.")
+                    await interaction.followup.send(
+                        embed=make_embed("❌ No results found for that query.", kind="error")
+                    )
                     return
-                
+
                 # Get the first video from search results
                 video_info = search_results['entries'][0]
                 video_id = video_info.get('id')
-                
+
                 if not video_id:
-                    await interaction.followup.send("❌ Could not extract video ID from search result.")
+                    await interaction.followup.send(
+                        embed=make_embed("❌ Could not extract video ID from search result.", kind="error")
+                    )
                     return
                 
                 # Build YouTube URL from video ID
@@ -76,7 +85,9 @@ async def play(interaction: discord.Interaction, query: str, bot):
                 info = ydl.extract_info(video_url, download=False)
             
             if not info:
-                await interaction.followup.send("❌ Could not retrieve video information.")
+                await interaction.followup.send(
+                    embed=make_embed("❌ Could not retrieve video information.", kind="error")
+                )
                 return
             
             # Try to get URL directly, or construct it from format data
@@ -100,7 +111,9 @@ async def play(interaction: discord.Interaction, query: str, bot):
             botLogger.info("audio URL: %s", audio_url)
             
             if not audio_url:
-                await interaction.followup.send("❌ Could not extract audio URL.")
+                await interaction.followup.send(
+                    embed=make_embed("❌ Could not extract audio URL.", kind="error")
+                )
                 return
 
             source = FFmpegPCMAudio(
@@ -124,11 +137,15 @@ async def play(interaction: discord.Interaction, query: str, bot):
 
             voice_client.play(source, after=after_playback)
             title = info.get('title', 'Unknown')
-            await interaction.followup.send(f"🎵 Now playing: **{title}**")
+            await interaction.followup.send(
+                embed=make_embed(f"🎵 Now playing: **{title}**", kind="success")
+            )
 
     except Exception as e:
         botLogger.error("yt-dlp extraction failed for query %r: %s", query, e, exc_info=True)
-        await interaction.followup.send(f"❌ An error occurred: {str(e)}")
+        await interaction.followup.send(
+            embed=make_embed(f"❌ An error occurred: {str(e)}", kind="error")
+        )
 
 @trace_function
 async def leave(interaction: discord.Interaction):
@@ -141,6 +158,10 @@ async def leave(interaction: discord.Interaction):
             interaction.guild.voice_client.stop()
         
         await interaction.guild.voice_client.disconnect()
-        await interaction.followup.send("👋 Disconnected from the voice channel.")
+        await interaction.followup.send(
+            embed=make_embed("👋 Disconnected from the voice channel.", kind="success")
+        )
     else:
-        await interaction.followup.send("❌ I'm not connected to any voice channel.")
+        await interaction.followup.send(
+            embed=make_embed("❌ I'm not connected to any voice channel.", kind="error")
+        )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -105,10 +105,21 @@ async def select_callback(interaction: discord.Interaction, user_choice: asyncio
         user_choice.set_result(selected_value)
     await interaction.response.defer()  # Acknowledge the interaction
 
+# builds a color-coded embed; kind in {success, error, info, warning}
+@trace_function
+def make_embed(description, *, kind="info", title=None):
+    color = {
+        "success": discord.Color.green(),
+        "error":   discord.Color.red(),
+        "info":    discord.Color.blurple(),
+        "warning": discord.Color.gold(),
+    }.get(kind, discord.Color.blurple())
+    return discord.Embed(title=title, description=description, color=color)
+
 # returns user selected option from dropdown user interaction
 @trace_function
 async def dropdown_interactions(interaction: discord.Interaction, list, initial_text):
-    # creete the dropdown menus from list 
+    # creete the dropdown menus from list
     select_menus = create_select_menus(list)
 
     # Create a view for the select menus
@@ -119,7 +130,7 @@ async def dropdown_interactions(interaction: discord.Interaction, list, initial_
         select_menu.callback = lambda interaction: select_callback(interaction, user_choice)
         view.add_item(select_menu)
 
-    await interaction.response.send_message(initial_text, view=view)
+    await interaction.response.send_message(embed=make_embed(initial_text, kind="info"), view=view)
     return await user_choice
 
 # endregion


### PR DESCRIPTION
Every plain-text response (RSS, MAL, voice, /auto_roulette, the >6 roulette fallback, background announcements, the global error handler, and the 5 nyaa error paths) now goes through a new make_embed helper in utils/utils.py and renders as a color-coded embed (success/error/info/ warning). The existing /nyaa and /roulette chart embeds are untouched. Existing copy is preserved verbatim, including the playful lines and the inline emojis.

announce_new_episode keeps mentions in `content` so subscriber pings still fire; all_rss_subscribe raises its file-fallback threshold from 2000 to 4096 to match embed-description headroom.