### PR TITLE
chore(config): add Claude Code skills and hooks

### DIFF
--- a/.claude/hooks/block-sensitive-files.ps1
+++ b/.claude/hooks/block-sensitive-files.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+    $cmd = $data.tool_input.command
+    if (-not $cmd) { exit 0 }
+
+    # Only inspect commands that START with `git add`. This is intentionally
+    # narrow: shell-level chaining ("cd foo && git add bar") is not handled,
+    # but the alternative -- regex-matching `git add` anywhere -- false-
+    # positives on commit message bodies, echo strings, etc. that mention
+    # the phrase. `git commit` is not checked here because gitignored files
+    # can't enter the index without an earlier `git add -f`, which this
+    # blocks. To bypass intentionally, run from a subshell.
+    $trimmed = $cmd.Trim()
+    if ($trimmed -notmatch '^git\s+add\b') { exit 0 }
+
+    $patterns = @(
+        @{ pattern = 'config[/\\]config-local\.json'; label = 'config/config-local.json (Discord token)' },
+        @{ pattern = '(^|[\s/\\])config-local\.json(\s|$)'; label = 'config-local.json' },
+        @{ pattern = '(^|[\s/\\])\.env(\s|$|[/\\])'; label = '.env' },
+        @{ pattern = '(^|[\s/\\])data[/\\]'; label = 'data/ (runtime state)' },
+        @{ pattern = '(^|\s)data($|\s)'; label = 'data (directory)' }
+    )
+    foreach ($p in $patterns) {
+        if ($trimmed -match $p.pattern) {
+            [Console]::Error.WriteLine("BLOCKED: 'git add' references gitignored / sensitive path: $($p.label)")
+            [Console]::Error.WriteLine("These paths hold the Discord token or runtime state and must not be staged.")
+            [Console]::Error.WriteLine("Stage specific safe files by name instead (e.g. git add bot.py functions/feed.py).")
+            exit 2
+        }
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/hooks/verify-commit-message.ps1
+++ b/.claude/hooks/verify-commit-message.ps1
@@ -1,0 +1,50 @@
+$ErrorActionPreference = 'Stop'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+    $cmd = $data.tool_input.command
+    if (-not $cmd) { exit 0 }
+
+    if ($cmd -notmatch '\bgit\s+commit\b') { exit 0 }
+
+    $hasMessage = ($cmd -match '\s-m\b') -or ($cmd -match '\s--message\b')
+    if (-not $hasMessage) { exit 0 }
+
+    $msg = $null
+
+    $heredocRe = [regex]'(?s)<<\s*[''"]?EOF[''"]?\s*\r?\n(.*?)\r?\n\s*EOF'
+    $hd = $heredocRe.Match($cmd)
+    if ($hd.Success) {
+        $msg = $hd.Groups[1].Value.Trim()
+    }
+    elseif ($cmd -match '-m\s+"([^"]+)"') {
+        $msg = $Matches[1]
+    }
+    elseif ($cmd -match "-m\s+'([^']+)'") {
+        $msg = $Matches[1]
+    }
+    elseif ($cmd -match '-m\s+(\S+)') {
+        $msg = $Matches[1]
+    }
+
+    if (-not $msg) { exit 0 }
+
+    $subject = ($msg -split "`n", 2)[0].Trim()
+
+    $pattern = '^(feat|fix|refactor|chore|docs|style)\((bot|feed|mal|nyaa|roulette|voice|tasks|utils|config|docker)\):\s+.+'
+    if ($subject -notmatch $pattern) {
+        [Console]::Error.WriteLine("BLOCKED: commit subject does not match CLAUDE.md format.")
+        [Console]::Error.WriteLine("Got:      $subject")
+        [Console]::Error.WriteLine("")
+        [Console]::Error.WriteLine("Required: <type>(<scope>): <subject in imperative mood>")
+        [Console]::Error.WriteLine("  type:   feat | fix | refactor | chore | docs | style")
+        [Console]::Error.WriteLine("  scope:  bot | feed | mal | nyaa | roulette | voice | tasks | utils | config | docker")
+        [Console]::Error.WriteLine("")
+        [Console]::Error.WriteLine("Example: feat(feed): add /rss remove command with dropdown confirmation")
+        exit 2
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/hooks/verify-commit-message.ps1
+++ b/.claude/hooks/verify-commit-message.ps1
@@ -6,7 +6,12 @@ try {
     $cmd = $data.tool_input.command
     if (-not $cmd) { exit 0 }
 
-    if ($cmd -notmatch '\bgit\s+commit\b') { exit 0 }
+    # Anchor to start of command so this hook does not false-positive when
+    # other commands (e.g. `gh pr create --body "..."`) mention "git commit"
+    # in a quoted body.
+    $trimmed = $cmd.Trim()
+    if ($trimmed -notmatch '^git\s+commit\b') { exit 0 }
+    $cmd = $trimmed
 
     $hasMessage = ($cmd -match '\s-m\b') -or ($cmd -match '\s--message\b')
     if (-not $hasMessage) { exit 0 }

--- a/.claude/hooks/warn-docker-jenkins-sync.ps1
+++ b/.claude/hooks/warn-docker-jenkins-sync.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+    $filePath = $data.tool_input.file_path
+    if (-not $filePath) { exit 0 }
+
+    $name = Split-Path -Leaf $filePath
+    if ($name -notin @('Dockerfile', 'Jenkinsfile', 'docker-compose.yml')) { exit 0 }
+
+    [Console]::Error.WriteLine("REMINDER: you edited $name.")
+    [Console]::Error.WriteLine("Per CLAUDE.md, these values must stay in sync across Dockerfile, Jenkinsfile, and docker-compose.yml:")
+    [Console]::Error.WriteLine("  - image / container name (mydiscordbot)")
+    [Console]::Error.WriteLine("  - external network (monitoring_monitoring)")
+    [Console]::Error.WriteLine("  - OTel endpoint (tempo:4317 -- also referenced in bot.py)")
+    [Console]::Error.WriteLine("  - mount paths (/app/data, /app/config/config.json)")
+    [Console]::Error.WriteLine("  - restart policy (unless-stopped)")
+    [Console]::Error.WriteLine("Run the sync-docker-jenkins skill to audit.")
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/hooks/warn-missing-trace.ps1
+++ b/.claude/hooks/warn-missing-trace.ps1
@@ -1,0 +1,47 @@
+$ErrorActionPreference = 'Stop'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+    $data = $raw | ConvertFrom-Json
+    $filePath = $data.tool_input.file_path
+    if (-not $filePath) { exit 0 }
+
+    $norm = $filePath -replace '\\', '/'
+
+    if ($norm -notmatch '/(functions|utils)/[^/]+\.py$') { exit 0 }
+    if ($norm -match '__init__\.py$') { exit 0 }
+    if (-not (Test-Path -LiteralPath $filePath)) { exit 0 }
+
+    $lines = Get-Content -LiteralPath $filePath
+    $missing = @()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        if ($line -match '^(async\s+)?def\s+(\w+)\s*\(') {
+            $funcName = $Matches[2]
+            if ($funcName -match '^__.*__$') { continue }
+
+            $hasTrace = $false
+            for ($j = $i - 1; $j -ge 0; $j--) {
+                $prev = $lines[$j].Trim()
+                if ($prev -eq '') { continue }
+                if ($prev -match '^@trace_function\b') { $hasTrace = $true; break }
+                if ($prev -match '^@') { continue }
+                break
+            }
+            if (-not $hasTrace) {
+                $lineNum = $i + 1
+                $missing += "  line ${lineNum}: $funcName"
+            }
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        [Console]::Error.WriteLine("WARNING: $filePath has function(s) missing @trace_function:")
+        $missing | ForEach-Object { [Console]::Error.WriteLine($_) }
+        [Console]::Error.WriteLine("Add 'from utils.tracing import trace_function' if needed, then decorate each function.")
+        [Console]::Error.WriteLine("Skipping the decorator fails silently -- no error, just missing spans in Tempo.")
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\block-sensitive-files.ps1\""
+          },
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\verify-commit-message.ps1\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\warn-missing-trace.ps1\""
+          },
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\warn-docker-jenkins-sync.ps1\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-slash-command/SKILL.md
+++ b/.claude/skills/add-slash-command/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: add-slash-command
+description: Scaffold a new Discord slash command end-to-end -- adds a handler in functions/<module>.py (decorated with @trace_function, using make_embed for responses) and registers it in bot.py with the standard @bot.tree.command wrapper. Use when the user asks to add, create, or scaffold a new /slash command.
+---
+
+# Add slash command
+
+Use this skill when the user asks to add a new Discord slash command to the bot.
+
+## What to collect from the user
+
+1. **Command name** -- kebab-case (e.g., `ping`, `weather`). Becomes the `/<name>` users type in Discord.
+2. **Description** -- one sentence shown in Discord's command picker.
+3. **Parameters** (zero or more) -- for each: name, Python type (`str`, `int`, etc.), short description.
+4. **Target module** -- usually a new `functions/<name>.py`. If the command logically extends an existing module (e.g., a new `/rss` subaction in `functions/feed.py`), add it there instead.
+
+Ask via AskUserQuestion if any of these are ambiguous. Don't proceed with placeholders.
+
+## Pattern reference
+
+Three pieces must all be present. See `functions/nyaa.py` and `bot.py` lines 116-120 for the canonical example.
+
+### Handler (in `functions/<module>.py`)
+
+```python
+import discord
+from utils.tracing import trace_function
+from utils.utils import make_embed
+
+@trace_function
+async def <name>(interaction: discord.Interaction, <params>):
+    # Use interaction.response.defer() for any operation that may take > 3s,
+    # then reply via interaction.followup.send(embed=...).
+    # For fast replies, use interaction.response.send_message(embed=...).
+    # Always build responses with make_embed(text, kind="success"|"error"|"info"|"warning", title=...)
+    await interaction.response.send_message(embed=make_embed("...", kind="info"))
+```
+
+### Registration (in `bot.py`, inside the relevant `#region` block)
+
+```python
+@bot.tree.command(name="<name>", description="<description>")
+@trace_function
+async def <name>_command(interaction: discord.Interaction, <params>):
+    botLogger.info('run <name>_command')
+    await <name>(interaction, <params>)
+```
+
+For parameters with constrained choices, also add `@app_commands.describe(...)` and `@app_commands.choices(...)` -- see `auto_roulette_command` in `bot.py:123-133`.
+
+### Required decorators
+
+- `@trace_function` on BOTH the wrapper in `bot.py` AND the handler in `functions/`. Forgetting either means missing OpenTelemetry spans in Tempo.
+- `@bot.tree.command(...)` must come ABOVE `@trace_function` on the wrapper (decorators are applied bottom-up; Discord.py needs to see the final wrapped callable).
+
+### Import in bot.py
+
+Add to the imports section near the top of `bot.py`:
+
+```python
+from functions.<module> import <name>
+```
+
+## Steps to execute
+
+1. Confirm the command name doesn't already exist -- grep for `bot.tree.command(name="<name>"` in `bot.py`.
+2. Create or edit the handler file in `functions/`.
+3. Add the import and the registration block in `bot.py` (place inside the matching `#region` block; create a new region if the command introduces a new domain).
+4. Tell the user the verification steps:
+   - Set `"debug": true` in `config/config-local.json` (skips OTel + background tasks for quick startup).
+   - Run `python bot.py`.
+   - In Discord, confirm `/<name>` appears in the command picker and responds correctly.
+   - Note: `bot.tree.sync()` runs on startup, but Discord may take up to an hour to propagate new commands globally. For instant testing, sync to a specific guild instead.
+
+## What NOT to do
+
+- Don't use raw `discord.Embed(...)` for simple text responses -- use `make_embed()` from `utils/utils.py` so colors stay consistent.
+- Don't put business logic in `bot.py`. The wrapper there should only log and delegate.
+- Don't skip `@trace_function`. It fails silently -- no error, just no observability. The `warn-missing-trace` hook will warn but not block.
+- Don't add a custom `try/except` that swallows exceptions. The global `on_app_command_error` handler in `bot.py` already converts unhandled exceptions to a user-friendly error embed.
+- Don't write the user's commit for them after scaffolding. Let the user review the diff and commit when ready. (If asked, use scope `bot` since the change touches `bot.py` and `functions/`.)

--- a/.claude/skills/sync-docker-jenkins/SKILL.md
+++ b/.claude/skills/sync-docker-jenkins/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: sync-docker-jenkins
+description: Audit Dockerfile, Jenkinsfile, and docker-compose.yml for drift in the values CLAUDE.md says must stay in sync (image name, network, OTel endpoint, mount paths, restart policy). Use when the user asks to verify Docker/Jenkins sync, or after editing any of those three files.
+---
+
+# Sync Docker / Jenkins / docker-compose
+
+CLAUDE.md ("Deployment" section) lists values that must agree across `Dockerfile`, `Jenkinsfile`, and `docker-compose.yml`. This skill reads all three and flags drift. It is read-only -- it does not modify files.
+
+## What to check
+
+| Value | Where to look | Expected |
+|---|---|---|
+| Image / container name | `Jenkinsfile` (`IMAGE_NAME`), `docker-compose.yml` (`container_name:`) | `mydiscordbot` |
+| External network | `docker-compose.yml` (`networks:` block) | `monitoring_monitoring` |
+| OTel endpoint | `bot.py` (`OTLPSpanExporter(endpoint=...)`); env override in compose if present | `tempo:4317` |
+| Data mount | `Dockerfile` (`WORKDIR` / `mkdir`), `docker-compose.yml` (`volumes:`) | host data dir -> `/app/data` |
+| Config mount | `docker-compose.yml` (`volumes:`) | host config.json -> `/app/config/config.json` |
+| Restart policy | `docker-compose.yml` (`restart:`) | `unless-stopped` |
+
+## How to run
+
+1. Read `Dockerfile`, `Jenkinsfile`, `docker-compose.yml`, and the OTel setup section of `bot.py`.
+2. Build a markdown table showing the actual value found in each file (or `-` if not present).
+3. Call out every row where values disagree, or where a value is missing in a file that should set it. Give the specific fix.
+4. Verify these common drift cases explicitly:
+   - `Jenkinsfile`'s `IMAGE_NAME` env var matches `docker-compose.yml`'s `container_name`.
+   - `docker-compose.yml` references the `monitoring_monitoring` external network.
+   - `bot.py`'s OTel endpoint is `tempo:4317` (not `localhost` or a different name).
+   - All data mount destinations resolve to `/app/data`.
+5. If everything is consistent, say so plainly: "all values are in sync, no drift detected".
+
+## Output format
+
+A markdown table plus a short prose section listing any drift with suggested fixes. Don't modify files -- this is an audit only. If the user wants the drift fixed afterward, they'll ask.
+
+## Why this matters
+
+The Jenkins pipeline (`docker compose build && docker compose up -d`) depends on the compose file being correct. If `bot.py` exports to `tempo:4317` but the container isn't on the `monitoring_monitoring` network, traces are silently dropped. If the data mount destination doesn't match `/app/data` (where the code reads/writes state), the bot starts with empty `data/` on every deploy, losing RSS subscriptions, roulette options, and the MAL anime list cache.


### PR DESCRIPTION
## Summary

Adds two project-scoped Claude Code skills and four hooks to enforce the discord-py patterns already documented in CLAUDE.md. All lives under `.claude/` and gets checked into the repo; `settings.local.json` (personal allowlist) is untouched.

### Skills (`.claude/skills/`)

- **add-slash-command** — scaffolds a new slash command end-to-end: handler in `functions/<module>.py` decorated with `@trace_function` and using `make_embed`, plus the `@bot.tree.command` wrapper in `bot.py`. References the canonical patterns at `bot.py:116-120` and `functions/nyaa.py`.
- **sync-docker-jenkins** — read-only audit that reports drift across `Dockerfile`, `Jenkinsfile`, and `docker-compose.yml` for the values CLAUDE.md says must stay in sync (image name, `monitoring_monitoring` network, `tempo:4317` OTel endpoint, `/app/data` and `/app/config/config.json` mounts, `unless-stopped` restart policy).

### Hooks (`.claude/hooks/`, wired up in `.claude/settings.json`)

| Hook | Event | Behavior |
|---|---|---|
| `block-sensitive-files.ps1` | PreToolUse · Bash | **BLOCKS** staging of `config/config-local.json`, `data/`, or `.env`. Only matches commands that start with `git add` so commit message bodies do not false-positive. |
| `verify-commit-message.ps1` | PreToolUse · Bash | **BLOCKS** commits whose subject does not match `<type>(<scope>): <subject>` with CLAUDE.md's type/scope lists. Handles regular quotes and HEREDOC syntax. |
| `warn-missing-trace.ps1` | PostToolUse · Edit\|Write | **ADVISORY** — flags functions in `functions/` or `utils/` that are missing `@trace_function`. Skips dunders and walks past other decorators. |
| `warn-docker-jenkins-sync.ps1` | PostToolUse · Edit\|Write | **ADVISORY** — reminds about the coupled values whenever you edit `Dockerfile`, `Jenkinsfile`, or `docker-compose.yml`. |

All hooks are PowerShell (Windows dev env) and fail-open on any error to avoid blocking legitimate work due to a hook bug. Two are blocking (clear-violation cases — a leaked Discord token is irreversible; non-conventional commits don't pass review), two are advisory.

The follow-up `fix(config)` commit narrows verify-commit-message to commands that START with `git commit`, after observing it false-positive on `gh pr create --body \"...\"` mentioning the phrase inside the PR body.

## Test plan

- [x] Adding the sensitive config file via the staging command is blocked (exit 2)
- [x] Adding a regular source file is allowed (exit 0)
- [x] A bad commit subject is blocked (exit 2)
- [x] A well-formed commit subject is allowed (exit 0)
- [x] A bad scope is blocked (exit 2)
- [x] Free text in a commit/PR body that merely mentions blocked phrases does NOT trigger either blocking hook
- [x] Editing Dockerfile prints the sync reminder (exit 0)
- [x] File with mixed traced/untraced functions: warning lists exactly the untraced ones (exit 0)
- [x] Fully-traced file: no warning (exit 0)

Skills will be exercised on the next slash command and the next Docker change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)