### PR TITLE
docs(claude): split monitoring docs into nested CLAUDE.md and fix drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Running the bot
 
 ```bash
-# Local development
+# Local development (requires DATABASE_URL pointing at a running Postgres)
 python bot.py
 
-# Docker
-docker build -t mydiscordbot .
-docker run mydiscordbot
+# Full local stack (bot + postgres + postgres-exporter)
+docker compose up -d --build
 ```
 
 There is no test suite. Verify behavior by running the bot directly.
@@ -26,43 +25,45 @@ The bot loads config from `config/config-local.json` if it exists, otherwise fal
 }
 ```
 
-Setting `debug: true` disables OpenTelemetry tracing and skips starting the background tasks (`check_for_new_anime` and `_run_new_episode_check_logic`).
+Setting `debug: true` disables OpenTelemetry tracing **and Pyroscope profiling**, and skips starting the background tasks (`check_for_new_anime` and `_run_new_episode_check_logic`).
+
+`DATABASE_URL` (env var, not in config file) must be set to a Postgres DSN — `bot.py` raises on startup if it's missing. In compose, this is set automatically; locally, point it at your own Postgres.
 
 ## Deployment
 
-Production deploys go through `Jenkinsfile` at the repo root. The pipeline builds the `mydiscordbot` image, stops + removes any running `discordbot` container, prunes dangling images, then runs a fresh container and verifies it's up.
+`Jenkinsfile` runs `docker compose build && docker compose up -d`. All container runtime config (image name, env, volumes, network, restart policy) lives in the root `docker-compose.yml` — Jenkins doesn't pass `-v` / `-e` flags directly anymore.
 
-Runtime container settings (from the pipeline — keep these in sync if you change them):
+The bot container attaches to the external `monitoring_monitoring` network so it can reach `tempo:4317`, `pyroscope:4040`, etc. If you rename that network or change the OTel endpoint in `bot.py`, update `docker-compose.yml` in the same commit (`chore(docker): ...`).
 
-- Image / container name: `mydiscordbot`
-- Network: `monitoring_monitoring` (external Docker network — the bot expects Tempo to be reachable at `tempo:4317` for OTel export)
-- Env: `OTEL_EXPORTER_OTLP_ENDPOINT=tempo:4317`
-- Volumes (host → container):
-  - `/home/izilov/Desktop/discord-files/` → `/app/data/`
-  - `/home/izilov/Desktop/discord-files/config.json` → `/app/config/config.json`
-- Restart policy: `unless-stopped`
+A separate `Deploy Monitoring` stage handles the observability stack; it only runs when `monitoring/**` changes. See `monitoring/CLAUDE.md` for that flow.
 
-If you change the image name, mount paths, network, or OTel endpoint in code or the Dockerfile, update the `Jenkinsfile` in the same commit (`chore(docker): ...`).
+### Root `docker-compose.yml`
 
-The monitoring stack lives in `monitoring/docker-compose.yml` (Prometheus, Grafana, Loki, Promtail, Tempo, OTel Collector, Alertmanager, Pyroscope, node-exporter). It is deployed by a separate `Deploy Monitoring` stage in `Jenkinsfile` that runs only when files under `monitoring/**` change. Grafana's admin password is read from `GRAFANA_ADMIN_PASSWORD`, injected by Jenkins from a **Secret text** credential with ID `grafana-admin-password` (Manage Jenkins → Credentials). The Discord webhook for Alertmanager comes from a second Secret-text credential `discord-alertmanager-webhook-url`; the `Deploy Monitoring` stage writes it to `monitoring/alertmanager/discord-webhook-url` (gitignored) before deploy, and Alertmanager reads it via `webhook_url_file:` in `alertmanager.yml`. For local dev, put `GRAFANA_ADMIN_PASSWORD=...` in `monitoring/.env` (gitignored) and the Discord webhook URL in `monitoring/alertmanager/discord-webhook-url`.
+Three services:
 
-Jenkins runs in a container that talks to the host Docker daemon, so the monitoring stack's relative bind mounts (`./loki/loki-config.yaml`) must resolve to a path the host can also see. The `Deploy Monitoring` stage rsyncs `monitoring/` into `/home/izilov/Desktop/discord-monitoring/` and runs `docker compose -p monitoring -f .../docker-compose.yml up -d` from there. That host path must be bind-mounted into the Jenkins container at the same path (`-v /home/izilov/Desktop/discord-monitoring:/home/izilov/Desktop/discord-monitoring`), and `rsync` must be installed in the Jenkins image. The `-p monitoring` flag pins the compose project name so the external network stays `monitoring_monitoring` (which the bot's compose attaches to).
+- **`db`** — `postgres:16-alpine`, named volume `postgres_data`, healthcheck via `pg_isready`.
+- **`bot`** — built from `Dockerfile`, `container_name: mydiscordbot`, `depends_on: db (service_healthy)`. `DATABASE_URL` is wired here. Mounts use `${DISCORD_DATA_PATH:-./data}` so Jenkins can point at `/home/izilov/Desktop/discord-files` while local dev uses `./data`.
+- **`postgres-exporter`** — `prometheuscommunity/postgres-exporter`, scraped by the monitoring stack's Prometheus over the shared network.
+
+`bot` and `postgres-exporter` join `default` (for db reachability) and `monitoring` (the external `monitoring_monitoring` network). `db` stays on `default` only — it's not exposed to the monitoring network directly.
 
 ## Architecture
 
-`bot.py` is the entry point. It registers all slash commands and wires them to handler functions in `functions/`. The command implementations do not live in `bot.py` — they are thin wrappers that delegate immediately.
+`bot.py` is the entry point. It registers all slash commands, sets up OTel + Pyroscope (when `debug: false`), and in `on_ready` initialises the asyncpg pool (`init_pool()` + `ensure_schema()`). Command implementations do not live in `bot.py` — they are thin wrappers that delegate to handlers in `functions/`.
 
 ```
-bot.py               ← slash command registration + OTel setup
+bot.py               ← slash command registration, OTel/Pyroscope setup, DB bootstrap
 config/
   consts.py          ← enums, file paths, channel IDs, Discord limits
   config.json        ← default config template
 utils/
   config.py          ← AppConfig loader (prefers config-local.json)
+  db.py              ← asyncpg pool + per-domain query helpers
   logger.py          ← botLogger (file + console)
   tracing.py         ← @trace_function decorator (sync + async)
-  utils.py           ← shared helpers: JSON/text I/O, dropdown UI, RSS parsing,
-                       MAL scraping (Selenium), roulette logic, chart generation
+  utils.py           ← shared helpers: dropdown UI, RSS parsing,
+                       MAL scraping (Selenium), roulette logic, chart generation,
+                       make_embed
 functions/
   feed.py            ← /rss command: add/view/remove/sub/unsub
   mal.py             ← /mal and /anime_list commands
@@ -70,26 +71,34 @@ functions/
   roulettes.py       ← /roulette and /auto_roulette commands
   tasks.py           ← background loops: hourly RSS check, daily MAL refresh
   voice.py           ← /play and /leave (yt-dlp + ffmpeg)
-data/                ← runtime state (gitignored)
-  rss_data.json      ← RSS subscriptions {series, title, link, pubDate, subs:[user_ids]}
-  mal_profile.txt    ← MAL usernames (one per line)
-  anime_list/{n}.txt ← cached anime lists keyed by MAL status int
-  roulette_options.txt ← saved auto-roulette option sets
+data/                ← runtime artifacts only (gitignored): logs, downloaded files.
+                       NOT persistent state — that lives in Postgres.
+monitoring/          ← observability stack — see monitoring/CLAUDE.md
 ```
 
 ## Key patterns
 
 **`@trace_function`** — every function (sync and async) is decorated with this. It wraps the function in an OpenTelemetry span. When `debug: true`, the tracer provider is never set up, so spans are no-ops. Do not add new functions without this decorator.
 
+**Data persistence (Postgres)** — all state lives in PostgreSQL, accessed through `utils/db.py`. It exposes:
+
+- `init_pool()` / `close_pool()` / `get_pool()` — asyncpg pool lifecycle.
+- `ensure_schema()` — idempotent `CREATE TABLE IF NOT EXISTS` for `roulette_options`, `rss_feeds`, `rss_subscriptions`, `mal_profiles`, `anime_list`. Called once from `on_ready`.
+- Per-domain helpers: `roulette_*`, `rss_*`, `mal_*`, `anime_list_*`. All decorated with `@trace_function`.
+
+When adding a new persistent feature, add a table to `ensure_schema()` and a new group of `<domain>_*` helpers — don't reach into the pool directly from `functions/`.
+
 **Dropdown interactions** — `dropdown_interactions()` in `utils/utils.py` is the standard way to show a Discord select menu and await the user's choice. It uses an `asyncio.Future` internally. Discord limits select menus to 25 items; `create_select_menus()` handles chunking automatically.
 
-**Data persistence** — all state is flat files in `data/`. JSON files use `load_json_data`/`save_json_data`; plain text files use `load_text_data`/`save_text_data` (one item per line). Both helpers in `utils/utils.py` handle missing files gracefully.
+**Embed responses** — `make_embed()` in `utils/utils.py` is the standard response wrapper. Use it for every command reply instead of building `discord.Embed` by hand, so titles/colors/footers stay consistent.
 
-**Background tasks** — `tasks.py` uses `discord.ext.tasks`. `_run_new_episode_check_logic` loops hourly to check for new RSS episodes and announce them to `OTAKU_CHANNEL_ID`. `check_for_new_anime` loops daily, scrapes MAL for currently-watching airing anime, and auto-adds matching RSS entries. Both tasks are only started when `debug: false`.
+**Background tasks** — `tasks.py` uses `discord.ext.tasks`. `_run_new_episode_check_logic` loops hourly to check for new RSS episodes (reading from `rss_feeds` / `rss_subscriptions`) and announce them to `OTAKU_CHANNEL_ID`. `check_for_new_anime` loops daily, scrapes MAL for currently-watching airing anime, and auto-adds matching RSS entries. Both tasks are only started when `debug: false`.
 
 **New episode announcements** — `announce_new_episode()` in `tasks.py` posts to `tormag.ezpz.work` to convert a magnet link into a shareable URL, then mentions all subscribed user IDs in `OTAKU_CHANNEL_ID`.
 
-**MAL scraping** — `scrape_mal()` in `utils/utils.py` uses Selenium with headless Chromium. Chrome must be installed (handled in Dockerfile via `chromium` + `chromium-driver`).
+**MAL scraping** — `scrape_mal()` in `utils/utils.py` uses Selenium with headless Chromium. Chrome must be installed (handled in `Dockerfile` via `chromium` + `chromium-driver`).
+
+**Pyroscope profiling** — when `debug: false`, `bot.py` also starts continuous profiling against `http://pyroscope:4040` with `oncpu=False` (captures blocking I/O like Discord WS, HTTP, Selenium) and `gil_only=False` (includes native threads — ffmpeg, chromium driver).
 
 ## Channel IDs
 
@@ -98,18 +107,18 @@ Hardcoded in `config/consts.py`:
 - `OTAKU_CHANNEL_ID` — new episode announcements and RSS notifications
 
 ## Git guidelines
- 
+
 ### Commit message format
- 
+
 ```
 <type>(<scope>): <short summary in imperative mood>
- 
+
 [optional body — wrap at 72 chars]
 [optional footer — Breaking change: ..., Closes #issue]
 ```
- 
+
 **Types**
- 
+
 | Type | When to use |
 |---|---|
 | `feat` | New user-visible feature or slash command |
@@ -118,31 +127,32 @@ Hardcoded in `config/consts.py`:
 | `chore` | Deps, config, Docker, CI — no production code |
 | `docs` | CLAUDE.md, README, inline comments only |
 | `style` | Formatting, linting — no logic change |
- 
-**Scopes** — match the file/module being changed: `bot`, `feed`, `mal`, `nyaa`, `roulette`, `voice`, `tasks`, `utils`, `config`, `docker`
- 
+
+**Scopes** — match the file/module being changed: `bot`, `feed`, `mal`, `nyaa`, `roulette`, `voice`, `tasks`, `utils`, `db`, `config`, `docker`, `monitoring`
+
 **Examples**
- 
+
 ```
 # Good
 feat(feed): add /rss remove command with dropdown confirmation
 fix(tasks): prevent duplicate episode announcements on restart
 chore(docker): pin chromium to 120.x for stable Selenium compat
- 
+
 # Bad
 fix stuff
 update bot.py
 WIP changes
 ```
- 
+
 ### Commit discipline
- 
+
 - **One logical change per commit.** Don't bundle a feature with an unrelated bugfix.
 - If a change touches `bot.py` and a `functions/` file for the same feature, that's one commit. If it touches `feed.py` and `mal.py` for unrelated reasons, split it.
 - Keep commits small enough that `git revert` is safe to use on each one.
-- Never commit: `config/config-local.json`, `data/`, `.env`, tokens, or secrets — these are gitignored for a reason.
+- Never commit: `config/config-local.json`, `data/`, `.env`, `monitoring/.env`, `monitoring/alertmanager/discord-webhook-url`, tokens, or secrets — these are gitignored for a reason.
+
 ### Branches and pushing
- 
+
 - Always work on a branch: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`
 - Open a PR — never push directly to `main` or force-push it
 - Squash trivial fixup commits before pushing (`git rebase -i`)

--- a/monitoring/CLAUDE.md
+++ b/monitoring/CLAUDE.md
@@ -1,0 +1,58 @@
+# monitoring/CLAUDE.md
+
+Guidance for the monitoring stack. The root `CLAUDE.md` covers the bot itself; this file loads only when something under `monitoring/` is being edited.
+
+## Stack
+
+All services are defined in `docker-compose.yml` and joined to the `monitoring` network (which the bot's root compose attaches to as the external `monitoring_monitoring` network — see below).
+
+| Service | Image | Purpose |
+|---|---|---|
+| `prometheus` | `prom/prometheus:v3.11.3` | Metrics. Rules in `prometheus/rules/`. Remote-write receiver enabled. |
+| `node-exporter` | `prom/node-exporter:v1.11.1` | Host metrics. Uses `network_mode: host`. |
+| `grafana` | `grafana/grafana:13.0.1` | UI. Provisioning + dashboards mounted from `grafana/`. |
+| `loki` | `grafana/loki:3.7.2` | Logs. Rules in `loki/rules/fake/`. |
+| `promtail` | `grafana/promtail:3.4.1` | Log shipper. Reads `/var/lib/docker/containers` and `/var/log`. |
+| `tempo` | `grafana/tempo:2.10.5` | Traces. Receives OTel on `4317`. |
+| `otel-collector` | `otel/opentelemetry-collector-contrib:0.111.0` | OTel gateway. Exposes `4317`/`4318`. |
+| `alertmanager` | `prom/alertmanager:v0.28.1` | Alerts → Discord webhook. |
+| `pyroscope` | `grafana/pyroscope:1.10.0` | Continuous profiling. Bot pushes to `http://pyroscope:4040`. |
+
+`postgres-exporter` runs in the **root** `docker-compose.yml` (not here) and is scraped by this Prometheus over the shared network.
+
+The bot exports traces to `tempo:4317` (hardcoded in `bot.py`) and profiles to `http://pyroscope:4040`.
+
+## Deploy flow
+
+`Jenkinsfile` at the repo root has a `Deploy Monitoring` stage that runs **only when `monitoring/**` changes** (`when { changeset 'monitoring/**' }`). The stage:
+
+1. `rsync -a --delete monitoring/` → `/home/izilov/Desktop/discord-monitoring/`
+2. Writes the Discord webhook secret to `alertmanager/discord-webhook-url` (gitignored)
+3. `docker compose -p monitoring -f /home/izilov/Desktop/discord-monitoring/docker-compose.yml up -d`
+
+The `-p monitoring` flag pins the project name so the network resolves to `monitoring_monitoring` — that's the name the bot's root compose expects to attach to as `external: true`. Do not remove `-p monitoring`.
+
+## Credentials (Jenkins secret-text)
+
+| Credential ID | Used as | Consumed by |
+|---|---|---|
+| `grafana-admin-password` | env `GRAFANA_ADMIN_PASSWORD` | Grafana via `GF_SECURITY_ADMIN_PASSWORD` |
+| `discord-alertmanager-webhook-url` | written to `alertmanager/discord-webhook-url` | Alertmanager via `webhook_url_file:` |
+
+For local dev: put `GRAFANA_ADMIN_PASSWORD=...` in `monitoring/.env` and the Discord webhook URL in `monitoring/alertmanager/discord-webhook-url`. Both are gitignored.
+
+## Alertmanager Discord webhook
+
+`alertmanager.yml` references the webhook via `webhook_url_file: /etc/alertmanager/discord-webhook-url` — never inline the URL into the YAML. The file is bind-mounted read-only into the container.
+
+## Host-path gotcha (Jenkins)
+
+Jenkins runs inside a container but talks to the **host** Docker daemon, so the bind-mount paths in `docker-compose.yml` (`./prometheus/prometheus.yml`, etc.) are resolved by the host, not by the Jenkins container. That's why the deploy rsyncs the whole `monitoring/` tree to `/home/izilov/Desktop/discord-monitoring/` on the host and runs compose from there.
+
+For this to work, the Jenkins container itself must have `/home/izilov/Desktop/discord-monitoring` bind-mounted at the **same path** (so `docker compose -f /home/izilov/...` inside Jenkins points at the same file the host daemon will resolve mounts against). `rsync` must be installed in the Jenkins image.
+
+## When editing files here
+
+- Touching a Prometheus rule, Grafana dashboard, Tempo config, etc. only requires re-running the `Deploy Monitoring` stage — push the change, Jenkins handles it.
+- Adding a new service: also confirm whether the bot or `postgres-exporter` needs to reach it; if so, no extra wiring needed (they're already on `monitoring_monitoring`), but document the port/endpoint in the bot's CLAUDE.md if it's user-visible.
+- Changing the network name or removing `-p monitoring`: breaks the bot's `monitoring_monitoring` external attachment. Don't.


### PR DESCRIPTION
Move monitoring stack details (service list, Deploy Monitoring stage, credentials, host-path gotcha) into monitoring/CLAUDE.md so they load only when files under monitoring/ are touched.

Fix factual drift in the root CLAUDE.md:
- State now lives in PostgreSQL via utils/db.py (asyncpg), not flat files
- Document the root docker-compose.yml (db, bot, postgres-exporter)
- Jenkinsfile now runs 'docker compose up -d', not raw docker run
- Note Pyroscope continuous profiling on bot.py startup
- Add make_embed() to documented key patterns