### PR TITLE
fix(docker): widen umask so alertmanager can read webhook file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 ]) {
                     sh '''
                         rsync -a --delete monitoring/ "$MONITORING_DEPLOY_PATH/"
-                        umask 077
+                        umask 133
                         printf "%s" "$DISCORD_WEBHOOK_URL" > "$MONITORING_DEPLOY_PATH/alertmanager/discord-webhook-url"
                         docker compose -p monitoring -f "$MONITORING_DEPLOY_PATH/docker-compose.yml" up -d
                     '''


### PR DESCRIPTION
## Summary
- Change `umask 077` to `umask 133` in the monitoring deploy stage so the `discord-webhook-url` file is created `644` instead of `600`.
- Required because Alertmanager runs as a different UID inside the container and could not read the owner-only file written by the Jenkins job.

## Test plan
- [x] Trigger the `Deploy Monitoring` Jenkins stage and confirm the job succeeds.
- [x] On the host, `ls -l $MONITORING_DEPLOY_PATH/alertmanager/discord-webhook-url` shows mode `-rw-r--r--`.
- [x] Alertmanager container starts cleanly and a test alert reaches the Discord webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)