### PR TITLE
feat: anime API layer + /mal_link command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,7 @@ from functions.roulettes import roulette, auto_roulette_menu
 from functions.voice import play, leave
 from functions.feed import rss_menu
 from functions.nyaa import search
-from functions.mal import mal_menu, anime_list_menu, next_anime
+from functions.mal import mal_menu, anime_list_menu, next_anime, mal_link
 from functions.tasks import _run_new_episode_check_logic, check_for_new_anime
 
 from opentelemetry import trace
@@ -218,7 +218,14 @@ async def next_anime_command(interaction: discord.Interaction):
     botLogger.info('run next_anime_command')
     await next_anime(interaction)
 
-#endregion 
+@bot.tree.command(name="mal_link", description="Bind your Discord account to your MAL username")
+@app_commands.describe(mal_username="Your MyAnimeList username (case-insensitive)")
+@trace_function
+async def mal_link_command(interaction: discord.Interaction, mal_username: str):
+    botLogger.info('run mal_link_command')
+    await mal_link(interaction, mal_username)
+
+#endregion
 
 bot.run(config.discord.token)
 botLogger.info('bot stop running.')

--- a/functions/mal.py
+++ b/functions/mal.py
@@ -3,7 +3,12 @@ from functions.roulettes import roulette
 from functions.roulettes import roulette
 from utils.utils import *
 from utils.tracing import trace_function
-from utils.db import mal_get_users, mal_add_user, mal_remove_user, anime_list_get
+from utils.db import (
+    mal_get_users, mal_add_user, mal_remove_user, anime_list_get,
+    mal_link_discord, mal_get_username_for_discord,
+    mal_snapshot_replace, mal_snapshot_updated_at, mal_activity_record,
+)
+from utils import anime_api
 
 
 @trace_function
@@ -86,3 +91,89 @@ async def view_anime_list(interaction, status):
         await interaction.response.send_message(
             embed=make_embed("No anime.", kind="info")
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-user MAL snapshot pipeline (Phase 1)
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_STALE_SECONDS = 6 * 60 * 60
+
+
+@trace_function
+async def _refresh_user_snapshot(username: str) -> int:
+    """Pull `username`'s full MAL list, replace their snapshot, write activity
+    rows for the diff. Returns the entry count fetched (0 = list private/empty)."""
+    entries = await anime_api.get_user_list(username)
+    if not entries:
+        return 0
+    diff = await mal_snapshot_replace(username, entries)
+    if diff:
+        await mal_activity_record([dict(d, username=username) for d in diff])
+    return len(entries)
+
+
+@trace_function
+async def _refresh_if_stale(username: str) -> None:
+    from datetime import datetime, timezone, timedelta
+    ts = await mal_snapshot_updated_at(username)
+    if ts is None or ts < datetime.now(tz=timezone.utc) - timedelta(seconds=SNAPSHOT_STALE_SECONDS):
+        await _refresh_user_snapshot(username)
+
+
+@trace_function
+async def mal_link(interaction: discord.Interaction, mal_username: str):
+    await interaction.response.defer(ephemeral=True)
+    mal_username = (mal_username or "").strip()
+    if not mal_username:
+        await interaction.followup.send(
+            embed=make_embed("❌ Please provide your MAL username.", kind="error"),
+            ephemeral=True,
+        )
+        return
+
+    existing = await mal_get_username_for_discord(interaction.user.id)
+    if existing and existing.lower() == mal_username.lower():
+        await interaction.followup.send(
+            embed=make_embed(f"Already linked to **{existing}**.", kind="info"),
+            ephemeral=True,
+        )
+        return
+
+    # Validate the MAL username exists and has a public list by trying a fetch.
+    entries = await anime_api.get_user_list(mal_username)
+    if not entries:
+        await interaction.followup.send(
+            embed=make_embed(
+                f"❌ Could not load **{mal_username}**'s list. "
+                "Username may be misspelled or the list is set to private.",
+                kind="error",
+            ),
+            ephemeral=True,
+        )
+        return
+
+    await mal_add_user(mal_username)
+    linked = await mal_link_discord(mal_username, interaction.user.id)
+    if not linked:
+        await interaction.followup.send(
+            embed=make_embed(
+                "❌ Your Discord account is already linked to a different MAL "
+                "user. Have an admin unbind it first.",
+                kind="error",
+            ),
+            ephemeral=True,
+        )
+        return
+
+    diff = await mal_snapshot_replace(mal_username, entries)
+    if diff:
+        await mal_activity_record([dict(d, username=mal_username) for d in diff])
+
+    await interaction.followup.send(
+        embed=make_embed(
+            f"✅ Linked to **{mal_username}** — {len(entries)} entries cached.",
+            kind="success",
+        ),
+        ephemeral=True,
+    )

--- a/utils/anime_api.py
+++ b/utils/anime_api.py
@@ -1,0 +1,246 @@
+import asyncio
+import time
+from typing import Any
+
+import aiohttp
+
+from config.consts import Statuses
+from utils.logger import botLogger
+from utils.tracing import trace_function
+
+JIKAN_BASE = "https://api.jikan.moe/v4"
+MAL_LIST_LOAD = "https://myanimelist.net/animelist/{user}/load.json"
+MAL_PAGE_SIZE = 300
+
+_session: aiohttp.ClientSession | None = None
+_session_lock = asyncio.Lock()
+
+_rate_sem = asyncio.Semaphore(2)
+_rate_min_interval = 0.35
+_last_request_at = 0.0
+_rate_lock = asyncio.Lock()
+
+_cache: dict[str, tuple[float, Any]] = {}
+
+_TTL = {
+    "/seasons/now":  3600,
+    "/anime":        21600,
+    "/anime_search": 1800,
+    "mal_list":      1800,
+}
+
+# Mapping from our Statuses enum to MAL's numeric status param for load.json.
+_MAL_STATUS_NUMERIC = {
+    Statuses.CURRENTLY_WATCHING.value: 1,
+    Statuses.COMPLETED.value:          2,
+    Statuses.ON_HOLD.value:            3,
+    Statuses.DROPPED.value:            4,
+    Statuses.PLAN_TO_WATCH.value:      6,
+}
+
+
+async def _get_session() -> aiohttp.ClientSession:
+    global _session
+    if _session is None or _session.closed:
+        async with _session_lock:
+            if _session is None or _session.closed:
+                _session = aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=15)
+                )
+    return _session
+
+
+def _cache_key(path: str, params: dict | None) -> str:
+    if not params:
+        return path
+    canonical = "&".join(f"{k}={params[k]}" for k in sorted(params))
+    return f"{path}?{canonical}"
+
+
+def _ttl_for(path: str, params: dict | None) -> int:
+    if path == "/seasons/now":
+        return _TTL["/seasons/now"]
+    if path.startswith("/users/"):
+        return _TTL["/users"]
+    if path == "/anime" and params and "q" in params:
+        return _TTL["/anime_search"]
+    if path.startswith("/anime/"):
+        return _TTL["/anime"]
+    return 600
+
+
+async def _throttled_get_url(
+    url: str,
+    params: dict | None = None,
+    *,
+    headers: dict | None = None,
+    cache_key: str | None = None,
+    ttl: int = 0,
+) -> Any | None:
+    """Generic throttled GET with retry. Caches when cache_key + ttl are provided."""
+    now = time.monotonic()
+    if cache_key:
+        cached = _cache.get(cache_key)
+        if cached and cached[0] > now:
+            return cached[1]
+
+    global _last_request_at
+    async with _rate_sem:
+        async with _rate_lock:
+            wait = _rate_min_interval - (time.monotonic() - _last_request_at)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            _last_request_at = time.monotonic()
+
+        session = await _get_session()
+        for attempt in range(2):
+            try:
+                async with session.get(url, params=params, headers=headers) as resp:
+                    if resp.status in (401, 403, 404):
+                        return None
+                    if resp.status == 429:
+                        retry_after = float(resp.headers.get("Retry-After", "1"))
+                        botLogger.warning("upstream 429 on %s, sleeping %ss", url, retry_after)
+                        await asyncio.sleep(retry_after)
+                        continue
+                    if 500 <= resp.status < 600:
+                        botLogger.warning("upstream %s on %s, retrying", resp.status, url)
+                        await asyncio.sleep(0.5 * (attempt + 1))
+                        continue
+                    resp.raise_for_status()
+                    data = await resp.json(content_type=None)
+            except aiohttp.ClientError as e:
+                botLogger.warning("network error on %s: %s", url, e)
+                if attempt == 1:
+                    raise
+                await asyncio.sleep(0.5)
+                continue
+
+            if cache_key and ttl > 0:
+                _cache[cache_key] = (now + ttl, data)
+            return data
+    return None
+
+
+@trace_function
+async def _throttled_get(path: str, params: dict | None = None, *, use_cache: bool = True) -> dict | None:
+    key = _cache_key(path, params) if use_cache else None
+    ttl = _ttl_for(path, params) if use_cache else 0
+    return await _throttled_get_url(f"{JIKAN_BASE}{path}", params, cache_key=key, ttl=ttl)
+
+
+@trace_function
+async def _mal_load_page(username: str, status_numeric: int, offset: int) -> list[dict] | None:
+    """Fetch one page (up to MAL_PAGE_SIZE entries) of a user's list from MAL's
+    internal load.json endpoint. Returns [] when the list is private/missing,
+    None on hard network failure."""
+    url = MAL_LIST_LOAD.format(user=username)
+    params = {"status": status_numeric, "offset": offset}
+    headers = {
+        "User-Agent": "Mozilla/5.0 (compatible; mydiscordbot/1.0)",
+        "Accept": "application/json",
+    }
+    key = f"mal_list:{username}:{status_numeric}:{offset}"
+    data = await _throttled_get_url(
+        url, params, headers=headers, cache_key=key, ttl=_TTL["mal_list"]
+    )
+    if data is None:
+        return []
+    return data if isinstance(data, list) else []
+
+
+@trace_function
+async def get_current_season() -> list[dict]:
+    results: list[dict] = []
+    page = 1
+    while True:
+        data = await _throttled_get("/seasons/now", {"page": page})
+        if not data:
+            break
+        results.extend(data.get("data", []))
+        pagination = data.get("pagination") or {}
+        if not pagination.get("has_next_page"):
+            break
+        page += 1
+        if page > 10:
+            break
+    return results
+
+
+@trace_function
+async def get_anime(mal_id: int) -> dict | None:
+    data = await _throttled_get(f"/anime/{mal_id}")
+    return data.get("data") if data else None
+
+
+@trace_function
+async def get_anime_full(mal_id: int) -> dict | None:
+    data = await _throttled_get(f"/anime/{mal_id}/full")
+    return data.get("data") if data else None
+
+
+@trace_function
+async def search_anime(query: str, limit: int = 10) -> list[dict]:
+    if not query:
+        return []
+    data = await _throttled_get("/anime", {"q": query, "limit": limit})
+    return data.get("data", []) if data else []
+
+
+@trace_function
+async def get_user_list(username: str, status: int | None = None) -> list[dict]:
+    """Fetch a user's MAL anime list via MAL's internal load.json endpoint.
+    Jikan v4 does not expose user lists, so we hit MAL directly.
+
+    Returns normalized entries with keys: mal_id, title, status, score,
+    episodes_watched. Empty list if the user doesn't exist or has a private list."""
+    if not username:
+        return []
+
+    if status is not None and status in _MAL_STATUS_NUMERIC:
+        status_codes = [_MAL_STATUS_NUMERIC[status]]
+    else:
+        status_codes = list(_MAL_STATUS_NUMERIC.values())
+
+    # Reverse map MAL numeric status -> our Statuses enum value.
+    reverse = {v: k for k, v in _MAL_STATUS_NUMERIC.items()}
+
+    results: list[dict] = []
+    for status_numeric in status_codes:
+        offset = 0
+        while True:
+            page = await _mal_load_page(username, status_numeric, offset)
+            if not page:
+                break
+            for entry in page:
+                mal_id = entry.get("anime_id")
+                title = entry.get("anime_title")
+                if not mal_id or not title:
+                    continue
+                raw_status = entry.get("status", status_numeric)
+                normalized_status = reverse.get(int(raw_status), status)
+                if normalized_status is None:
+                    continue
+                score = entry.get("score")
+                results.append({
+                    "mal_id":           int(mal_id),
+                    "title":            title,
+                    "status":           int(normalized_status),
+                    "score":            int(score) if score else None,
+                    "episodes_watched": int(entry.get("num_watched_episodes") or 0),
+                })
+            if len(page) < MAL_PAGE_SIZE:
+                break
+            offset += MAL_PAGE_SIZE
+            if offset >= 7500:
+                botLogger.warning("get_user_list hit 7500-entry safety stop for %s", username)
+                break
+    return results
+
+
+@trace_function
+async def close() -> None:
+    global _session
+    if _session and not _session.closed:
+        await _session.close()
+        _session = None

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 import asyncpg
 
@@ -78,6 +79,52 @@ async def ensure_schema() -> None:
                 status     INTEGER     NOT NULL,
                 title      TEXT        NOT NULL,
                 UNIQUE (status, title)
+            )
+        """)
+        await conn.execute("""
+            ALTER TABLE mal_profiles
+            ADD COLUMN IF NOT EXISTS discord_user_id BIGINT UNIQUE
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS mal_list_snapshots (
+                username         TEXT        NOT NULL REFERENCES mal_profiles(username) ON DELETE CASCADE,
+                mal_id           INTEGER     NOT NULL,
+                title            TEXT        NOT NULL,
+                status           INTEGER     NOT NULL,
+                score            INTEGER,
+                episodes_watched INTEGER     NOT NULL DEFAULT 0,
+                updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (username, mal_id)
+            )
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS mal_list_snapshots_status_mal_id_idx
+            ON mal_list_snapshots(status, mal_id)
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS mal_activity (
+                id             BIGSERIAL   PRIMARY KEY,
+                username       TEXT        NOT NULL,
+                mal_id         INTEGER     NOT NULL,
+                delta_episodes INTEGER     NOT NULL,
+                new_status     INTEGER,
+                score          INTEGER,
+                recorded_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS mal_activity_username_recorded_idx
+            ON mal_activity(username, recorded_at)
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS mal_activity_recorded_idx
+            ON mal_activity(recorded_at)
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS episode_announcements (
+                message_id   BIGINT      PRIMARY KEY,
+                series       TEXT        NOT NULL,
+                announced_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
         """)
     botLogger.info("schema ensured")
@@ -348,3 +395,275 @@ async def anime_list_replace(status: int, titles: list[str]) -> None:
                     status,
                     titles,
                 )
+
+
+# ---------------------------------------------------------------------------
+# MAL link / snapshots / activity
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def mal_link_discord(username: str, discord_user_id: int) -> bool:
+    """Bind a Discord user id to a MAL username. Returns False if discord_user_id
+    is already bound to a different username, or if `username` doesn't exist in
+    mal_profiles. Caller should ensure the row exists via mal_add_user first."""
+    async with get_pool().acquire() as conn:
+        existing = await conn.fetchrow(
+            "SELECT username FROM mal_profiles WHERE discord_user_id = $1",
+            discord_user_id,
+        )
+        if existing and existing["username"] != username:
+            return False
+        result = await conn.execute(
+            "UPDATE mal_profiles SET discord_user_id = $1 WHERE username = $2",
+            discord_user_id, username,
+        )
+    return result.endswith("1")
+
+
+@trace_function
+async def mal_get_username_for_discord(discord_user_id: int) -> str | None:
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT username FROM mal_profiles WHERE discord_user_id = $1",
+            discord_user_id,
+        )
+    return row["username"] if row else None
+
+
+@trace_function
+async def mal_get_discord_for_username(username: str) -> int | None:
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT discord_user_id FROM mal_profiles WHERE username = $1",
+            username,
+        )
+    return row["discord_user_id"] if row and row["discord_user_id"] else None
+
+
+@trace_function
+async def mal_snapshot_replace(username: str, entries: list[dict]) -> list[dict]:
+    """Atomically replace the snapshot for `username`. Each entry: mal_id, title,
+    status, score, episodes_watched. Returns diff rows the caller can persist to
+    mal_activity (only rows where episodes grew or status changed)."""
+    diff: list[dict] = []
+    async with get_pool().acquire() as conn:
+        async with conn.transaction():
+            old_rows = await conn.fetch(
+                "SELECT mal_id, status, episodes_watched FROM mal_list_snapshots WHERE username = $1",
+                username,
+            )
+            old = {r["mal_id"]: r for r in old_rows}
+
+            for e in entries:
+                mal_id = int(e["mal_id"])
+                new_status = int(e["status"])
+                new_eps = int(e.get("episodes_watched") or 0)
+                score = e.get("score")
+                score = int(score) if score else None
+
+                if mal_id in old:
+                    delta = new_eps - int(old[mal_id]["episodes_watched"])
+                    status_changed = int(old[mal_id]["status"]) != new_status
+                else:
+                    delta = new_eps
+                    status_changed = True
+
+                if delta > 0 or status_changed:
+                    diff.append({
+                        "mal_id":         mal_id,
+                        "title":          e["title"],
+                        "delta_episodes": max(delta, 0),
+                        "new_status":     new_status if status_changed else None,
+                        "score":          score,
+                    })
+
+            await conn.execute(
+                "DELETE FROM mal_list_snapshots WHERE username = $1",
+                username,
+            )
+            if entries:
+                await conn.executemany(
+                    """
+                    INSERT INTO mal_list_snapshots
+                        (username, mal_id, title, status, score, episodes_watched, updated_at)
+                    VALUES ($1, $2, $3, $4, $5, $6, NOW())
+                    """,
+                    [
+                        (
+                            username,
+                            int(e["mal_id"]),
+                            e["title"],
+                            int(e["status"]),
+                            int(e["score"]) if e.get("score") else None,
+                            int(e.get("episodes_watched") or 0),
+                        )
+                        for e in entries
+                    ],
+                )
+    return diff
+
+
+@trace_function
+async def mal_snapshot_get(username: str, status: int | None = None) -> list[dict]:
+    async with get_pool().acquire() as conn:
+        if status is None:
+            rows = await conn.fetch(
+                """
+                SELECT mal_id, title, status, score, episodes_watched, updated_at
+                FROM mal_list_snapshots WHERE username = $1
+                ORDER BY title ASC
+                """,
+                username,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT mal_id, title, status, score, episodes_watched, updated_at
+                FROM mal_list_snapshots WHERE username = $1 AND status = $2
+                ORDER BY title ASC
+                """,
+                username, status,
+            )
+    return [dict(r) for r in rows]
+
+
+@trace_function
+async def mal_snapshot_updated_at(username: str) -> datetime | None:
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT MAX(updated_at) AS ts FROM mal_list_snapshots WHERE username = $1",
+            username,
+        )
+    return row["ts"] if row else None
+
+
+@trace_function
+async def mal_who_has(mal_id: int, statuses: list[int]) -> list[str]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT username FROM mal_list_snapshots
+            WHERE mal_id = $1 AND status = ANY($2::int[])
+            ORDER BY username ASC
+            """,
+            mal_id, statuses,
+        )
+    return [r["username"] for r in rows]
+
+
+@trace_function
+async def mal_activity_record(rows: list[dict]) -> None:
+    if not rows:
+        return
+    async with get_pool().acquire() as conn:
+        await conn.executemany(
+            """
+            INSERT INTO mal_activity (username, mal_id, delta_episodes, new_status, score)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            [
+                (
+                    r["username"],
+                    int(r["mal_id"]),
+                    int(r["delta_episodes"]),
+                    int(r["new_status"]) if r.get("new_status") is not None else None,
+                    int(r["score"]) if r.get("score") is not None else None,
+                )
+                for r in rows
+            ],
+        )
+
+
+@trace_function
+async def mal_activity_episodes_by_month(username: str, months: int = 12) -> list[tuple[str, int]]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT to_char(date_trunc('month', recorded_at), 'YYYY-MM') AS month,
+                   COALESCE(SUM(delta_episodes), 0)::int AS total
+            FROM mal_activity
+            WHERE username = $1
+              AND recorded_at >= NOW() - ($2 || ' months')::interval
+            GROUP BY 1
+            ORDER BY 1 ASC
+            """,
+            username, str(months),
+        )
+    return [(r["month"], r["total"]) for r in rows]
+
+
+@trace_function
+async def mal_score_distribution(username: str) -> dict[int, int]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT score, COUNT(*)::int AS n
+            FROM mal_list_snapshots
+            WHERE username = $1 AND score IS NOT NULL AND score > 0
+            GROUP BY score
+            ORDER BY score ASC
+            """,
+            username,
+        )
+    return {int(r["score"]): int(r["n"]) for r in rows}
+
+
+@trace_function
+async def mal_activity_leaderboard(since: datetime) -> list[tuple[str, int]]:
+    async with get_pool().acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT username, COALESCE(SUM(delta_episodes), 0)::int AS total
+            FROM mal_activity
+            WHERE recorded_at >= $1
+            GROUP BY username
+            HAVING SUM(delta_episodes) > 0
+            ORDER BY total DESC
+            """,
+            since,
+        )
+    return [(r["username"], r["total"]) for r in rows]
+
+
+@trace_function
+async def mal_alltime_leader() -> tuple[str, int] | None:
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT username, COALESCE(SUM(episodes_watched), 0)::int AS total
+            FROM mal_list_snapshots
+            GROUP BY username
+            ORDER BY total DESC
+            LIMIT 1
+            """
+        )
+    if not row or row["total"] <= 0:
+        return None
+    return (row["username"], row["total"])
+
+
+# ---------------------------------------------------------------------------
+# Episode announcements (for reaction-subscribe)
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def episode_announcement_record(message_id: int, series: str) -> None:
+    async with get_pool().acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO episode_announcements (message_id, series)
+            VALUES ($1, $2)
+            ON CONFLICT (message_id) DO NOTHING
+            """,
+            message_id, series,
+        )
+
+
+@trace_function
+async def episode_announcement_get_series(message_id: int) -> str | None:
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT series FROM episode_announcements WHERE message_id = $1",
+            message_id,
+        )
+    return row["series"] if row else None


### PR DESCRIPTION
## Summary
- New `utils/anime_api.py` — async Jikan v4 wrapper for anime metadata, plus a MAL `load.json` fallback for per-user lists (Jikan v4 has no user-list endpoint). Shared ratelimiter (~3 rps), 429/5xx retry, per-endpoint TTL cache.
- `utils/db.py` — idempotent schema migration: adds `discord_user_id` to `mal_profiles`, plus three new tables (`mal_list_snapshots`, `mal_activity`, `episode_announcements`) with the helpers backing the snapshot/activity/leaderboard/reaction-subscribe pipelines that land in follow-up PRs.
- `/mal_link <mal_username>` — new ephemeral slash command that validates the MAL username, binds it to the caller's Discord ID, and seeds the snapshot + activity tables. Foundation for `/mal_compare`, `/mal_stats`, `/anime_recommend`, `/who_is_watching`, leaderboard, and milestones in later PRs.

Existing commands (`/mal`, `/anime_list`, `/next_anime`, `/play`, `/leave`, `/rss`, `/nyaa`, `/roulette`, `/auto_roulette`) are untouched.

## Test plan
- [ ] Boot the bot with `debug: true` against a Postgres that has the previous schema applied. First start should log `schema ensured` and the `ALTER TABLE mal_profiles` should be a no-op.
- [ ] `psql` check: `\d mal_profiles` shows the new `discord_user_id` column. `\d mal_list_snapshots`, `\d mal_activity`, `\d episode_announcements` are present.
- [ ] In Discord, run `/mal_link <your-mal-username>` — expect "✅ Linked to **X** — N entries cached" (ephemeral).
- [ ] `SELECT discord_user_id FROM mal_profiles WHERE username='...'` returns your Discord ID. `SELECT count(*) FROM mal_list_snapshots WHERE username='...'` is non-zero.
- [ ] Re-run `/mal_link` with the same username → "Already linked to **X**".
- [ ] Try a non-existent / private MAL username → "❌ Could not load **X**'s list..." error embed.
- [ ] OTel traces (when not in debug) show spans for `_throttled_get_url`, `get_user_list`, `mal_snapshot_replace`, `mal_link`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)