### PR TITLE
feat(season): /season_anime + 🔔 reaction-subscribe

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,10 @@ from functions.mal import (
     mal_menu, anime_list_menu, next_anime, mal_link,
     next_episode, mal_compare, mal_stats, anime_recommend, who_is_watching,
 )
+from functions.season import season_anime
 from functions.tasks import _run_new_episode_check_logic, check_for_new_anime
+from utils.db import episode_announcement_get_series, rss_subscribe
+from config.consts import OTAKU_CHANNEL_ID
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -93,6 +96,37 @@ async def on_error(event, *args, **kwargs):
         exc,
         "".join(traceback.format_exception(exc_type, exc, tb)),
     )
+
+
+REACTION_SUBSCRIBE_EMOJI = "🔔"
+
+
+@bot.event
+@trace_function
+async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
+    if payload.user_id == bot.user.id:
+        return
+    if payload.channel_id != OTAKU_CHANNEL_ID:
+        return
+    if str(payload.emoji) != REACTION_SUBSCRIBE_EMOJI:
+        return
+
+    series = await episode_announcement_get_series(payload.message_id)
+    if not series:
+        return
+
+    if not await rss_subscribe(series, payload.user_id):
+        return  # already subscribed — no need to DM again
+
+    user = bot.get_user(payload.user_id) or await bot.fetch_user(payload.user_id)
+    if user is None:
+        return
+    try:
+        await user.send(
+            embed=make_embed(f"✅ Subscribed to **{series}** via 🔔 reaction.", kind="success")
+        )
+    except discord.HTTPException as e:
+        botLogger.info("could not DM %s after reaction-subscribe: %s", payload.user_id, e)
 
 
 @bot.tree.error
@@ -260,6 +294,16 @@ async def anime_recommend_command(interaction: discord.Interaction):
 async def who_is_watching_command(interaction: discord.Interaction, anime: str):
     botLogger.info('run who_is_watching_command')
     await who_is_watching(interaction, anime)
+
+#endregion
+
+#region Season
+
+@bot.tree.command(name="season_anime", description="Browse this season's airing anime, subscribe with the 🔔 button")
+@trace_function
+async def season_anime_command(interaction: discord.Interaction):
+    botLogger.info('run season_anime_command')
+    await season_anime(interaction)
 
 #endregion
 

--- a/functions/season.py
+++ b/functions/season.py
@@ -1,0 +1,100 @@
+import discord
+
+from utils import anime_api
+from utils.db import rss_get_series_list, rss_subscribe
+from utils.tracing import trace_function
+from utils.utils import make_embed
+from functions.tasks import string_similar
+
+SEASON_VIEW_TIMEOUT = 900  # 15 minutes
+
+
+async def _try_subscribe(user_id: int, anime_title: str) -> str:
+    """Subscribe `user_id` to whichever rss_feeds series fuzzy-matches
+    `anime_title`. Returns a user-facing message."""
+    all_series = await rss_get_series_list()
+    anime_norm = (anime_title or "").strip().lower()
+    if not anime_norm:
+        return "❌ Anime title is empty."
+
+    for series in all_series:
+        if string_similar(series.strip().lower(), anime_norm):
+            ok = await rss_subscribe(series, user_id)
+            if ok:
+                return f"✅ Subscribed to **{series}** — you'll be pinged on new episodes."
+            return f"You're already subscribed to **{series}**."
+
+    return (
+        "📡 No RSS feed exists for this series yet. The bot auto-detects feeds "
+        "once SubsPlease starts releasing episodes — come back and run "
+        "`/rss sub_to_rss` then."
+    )
+
+
+class SeasonView(discord.ui.View):
+    def __init__(self, anime_list: list[dict]):
+        super().__init__(timeout=SEASON_VIEW_TIMEOUT)
+        self.anime_list = anime_list
+        self.page = 0
+
+    def render_embed(self) -> discord.Embed:
+        anime = self.anime_list[self.page]
+        title = anime.get("title") or "Unknown"
+        score = anime.get("score")
+        broadcast = ((anime.get("broadcast") or {}).get("string")) or "Schedule unknown"
+        synopsis_full = anime.get("synopsis") or ""
+        synopsis = synopsis_full[:400] + ("…" if len(synopsis_full) > 400 else "")
+        genres = ", ".join(g["name"] for g in (anime.get("genres") or [])[:4]) or None
+        url = anime.get("url")
+
+        lines = [f"**Broadcast:** {broadcast}"]
+        if score:
+            lines.append(f"**Score:** {score}/10")
+        if genres:
+            lines.append(f"**Genres:** {genres}")
+        if url:
+            lines.append(f"[MyAnimeList]({url})")
+        lines.append("")
+        lines.append(synopsis or "_No synopsis available._")
+
+        embed = make_embed("\n".join(lines), kind="info", title=title)
+        image = (((anime.get("images") or {}).get("jpg") or {}).get("large_image_url")
+                 or ((anime.get("images") or {}).get("jpg") or {}).get("image_url"))
+        if image:
+            embed.set_thumbnail(url=image)
+        embed.set_footer(
+            text=f"Page {self.page + 1}/{len(self.anime_list)} • Buttons expire after 15 min"
+        )
+        return embed
+
+    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
+    async def prev(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.page = (self.page - 1) % len(self.anime_list)
+        await interaction.response.edit_message(embed=self.render_embed(), view=self)
+
+    @discord.ui.button(label="🔔 Subscribe", style=discord.ButtonStyle.success)
+    async def subscribe(self, interaction: discord.Interaction, button: discord.ui.Button):
+        anime = self.anime_list[self.page]
+        msg = await _try_subscribe(interaction.user.id, anime.get("title") or "")
+        kind = "success" if msg.startswith("✅") else "info"
+        await interaction.response.send_message(
+            embed=make_embed(msg, kind=kind), ephemeral=True
+        )
+
+    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
+    async def next_(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.page = (self.page + 1) % len(self.anime_list)
+        await interaction.response.edit_message(embed=self.render_embed(), view=self)
+
+
+@trace_function
+async def season_anime(interaction: discord.Interaction):
+    await interaction.response.defer()
+    season = await anime_api.get_current_season()
+    if not season:
+        await interaction.followup.send(
+            embed=make_embed("Could not fetch the current season from Jikan.", kind="error")
+        )
+        return
+    view = SeasonView(season)
+    await interaction.followup.send(embed=view.render_embed(), view=view)

--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -1,7 +1,10 @@
 import requests
 from utils.utils import *
 from utils.tracing import trace_function
-from utils.db import rss_get_all_episodes, rss_update_episode, rss_add_feed, rss_get_series_list
+from utils.db import (
+    rss_get_all_episodes, rss_update_episode, rss_add_feed, rss_get_series_list,
+    episode_announcement_record,
+)
 from fuzzywuzzy import fuzz
 from datetime import datetime
 from discord.ext import tasks
@@ -15,7 +18,7 @@ def parse_pub_date(date_str):
 
 # Creates magnet url for the new rss episode
 @trace_function
-async def announce_new_episode(title, magnet_link, subs, bot):
+async def announce_new_episode(title, magnet_link, subs, bot, series=None):
     channel = bot.get_channel(OTAKU_CHANNEL_ID)
     # Insert magnet link into API (if required)
     apiUrl          = "https://tormag.ezpz.work/api/api.php?action=insertMagnets"
@@ -27,18 +30,25 @@ async def announce_new_episode(title, magnet_link, subs, bot):
     except (requests.RequestException, ValueError) as e:
         botLogger.error("tormag conversion failed: %s", e)
 
+    sent_message = None
     # Check if the response contains the magnet entries
     if responseJson and "magnetEntries" in responseJson and responseJson["magnetEntries"]:
         magnet_url = responseJson["magnetEntries"][0]  # Get the first magnet URL
         # Mentions live in `content` so they actually ping subscribers; the embed is just the formatted link
         user_mentions = " ".join([f"<@{user_id}>" for user_id in subs])
         embed = make_embed(f"New Episode Available: [{title}]({magnet_url})", kind="success")
-        await channel.send(content=user_mentions, embed=embed)
+        sent_message = await channel.send(content=user_mentions, embed=embed)
     else:
         # If no magnet URL is available or URL limit reached, log the error
         message = (responseJson or {}).get('message', 'tormag unreachable')
         formatted_message = (f"Error for {title}: {message} \nhere is the magnet instead :D : \n{magnet_link}")
         await channel.send(embed=make_embed(formatted_message, kind="error"))
+
+    if sent_message is not None and series:
+        # Map the announcement message back to its series so an on_raw_reaction_add
+        # listener can resolve series for reaction-based subscription.
+        await episode_announcement_record(sent_message.id, series)
+
     botLogger.info('finished announcing new episode')
 
 
@@ -65,7 +75,13 @@ async def check_for_new_episodes(bot):
                     feed_entry["link"],
                     feed_entry["size"],
                 )
-                await announce_new_episode(feed_entry["title"], feed_entry["link"], matching_entry["subs"], bot)
+                await announce_new_episode(
+                    feed_entry["title"],
+                    feed_entry["link"],
+                    matching_entry["subs"],
+                    bot,
+                    series=feed_entry["series"],
+                )
 
     botLogger.info('rss_check_complete')
 


### PR DESCRIPTION
## Summary
- **`/season_anime`** — paginated browser over the current season (`anime_api.get_current_season` via Jikan `/seasons/now`). One anime per page with title, broadcast slot, score, genres, synopsis, MAL link, and cover thumbnail. View has prev/next/🔔 Subscribe buttons; expires after 15 min.
- **Subscribe button** — fuzzy-matches the anime title against existing `rss_feeds` via `string_similar` (existing fuzz>0.85 / TF-IDF helper). On match: `rss_subscribe`. No match: tells the user the feed doesn't exist yet and to `/rss sub_to_rss` once it does.
- **🔔 reaction-subscribe** — `announce_new_episode` now records `message_id → series` in `episode_announcements` after posting. New `on_raw_reaction_add` dispatcher in `bot.py` filters to OTAKU channel + 🔔, resolves the series via the table, calls `rss_subscribe`, and DMs the user a confirmation embed when newly subscribed.

Existing commands all untouched.

## Test plan
- [ ] `docker compose up -d --build`, `docker compose logs -f bot` for clean boot.
- [ ] `/season_anime` — paginates through current season; prev/next cycles correctly; cover thumbnail renders.
- [ ] On a season anime that matches an existing RSS feed: 🔔 Subscribe → ephemeral `✅ Subscribed to **X** …`, confirm with `/rss view_rss`.
- [ ] On a season anime that DOESN'T match: 🔔 Subscribe → `📡 No RSS feed exists for this series yet…`.
- [ ] Wait 15 min; clicking a button should silently fail (view timed out). User can re-run `/season_anime`.
- [ ] Reaction-subscribe: hand-trigger an episode announcement (or wait for the hourly task in non-debug), then react 🔔 to it. Expect a DM `✅ Subscribed to **X** via 🔔 reaction.` and a new row in `rss_subscriptions`.
- [ ] React 🔔 a second time on the same announcement → no duplicate DM (already subscribed).
- [ ] React with a different emoji → no action.
- [ ] Regression: every previously-shipped command still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)