### PR TITLE
feat(voice): music queue — /queue_play /skip /queue /now_playing /op

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,7 @@ from utils.utils import make_embed
 # all discord user functions
 from functions.roulettes import roulette, auto_roulette_menu
 from functions.voice import play, leave
+from functions.queue import queue_play, skip_track, queue_show, now_playing, op_play
 from functions.feed import rss_menu
 from functions.nyaa import search
 from functions.mal import (
@@ -187,6 +188,38 @@ async def leave_command(interaction: discord.Interaction):
 async def play_command(interaction: discord.Interaction, query: str):
     botLogger.info('run play_command')
     await play(interaction, query, bot)
+
+@bot.tree.command(name="queue_play", description="Queue a track (joins the queue if something is already playing)")
+@app_commands.describe(query="YouTube URL or search query")
+@trace_function
+async def queue_play_command(interaction: discord.Interaction, query: str):
+    botLogger.info('run queue_play_command')
+    await queue_play(interaction, query)
+
+@bot.tree.command(name="skip", description="Skip the currently playing track")
+@trace_function
+async def skip_command(interaction: discord.Interaction):
+    botLogger.info('run skip_command')
+    await skip_track(interaction)
+
+@bot.tree.command(name="queue", description="Show the current music queue")
+@trace_function
+async def queue_command(interaction: discord.Interaction):
+    botLogger.info('run queue_command')
+    await queue_show(interaction)
+
+@bot.tree.command(name="now_playing", description="Show the currently playing track")
+@trace_function
+async def now_playing_command(interaction: discord.Interaction):
+    botLogger.info('run now_playing_command')
+    await now_playing(interaction)
+
+@bot.tree.command(name="op", description="Queue an anime opening from YouTube")
+@app_commands.describe(anime="Name of the anime")
+@trace_function
+async def op_command(interaction: discord.Interaction, anime: str):
+    botLogger.info('run op_command')
+    await op_play(interaction, anime)
 
 #endregion
 

--- a/functions/queue.py
+++ b/functions/queue.py
@@ -1,0 +1,300 @@
+import asyncio
+from dataclasses import dataclass
+
+import discord
+import yt_dlp
+from discord import FFmpegPCMAudio
+
+from utils.logger import botLogger
+from utils.tracing import trace_function
+from utils.utils import make_embed
+
+IDLE_DISCONNECT_SECONDS = 300
+
+_queues: dict[int, list["QueueEntry"]] = {}
+_now_playing: dict[int, "QueueEntry"] = {}
+_player_tasks: dict[int, asyncio.Task] = {}
+_queue_events: dict[int, asyncio.Event] = {}
+
+
+@dataclass
+class QueueEntry:
+    title: str
+    audio_url: str
+    webpage_url: str
+    requested_by: int
+    duration: int | None = None
+
+
+def _yt_extract(query: str) -> dict | None:
+    """Synchronous yt-dlp extraction. Returns the best audio info dict or None.
+    Run via asyncio.to_thread to keep the event loop responsive."""
+    ydl_opts = {"format": "bestaudio/best", "quiet": True, "noplaylist": True}
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        is_url = "https://" in query or "youtube.com" in query or "youtu.be" in query
+        if is_url:
+            info = ydl.extract_info(query, download=False)
+        else:
+            results = ydl.extract_info(f"ytsearch:{query}", download=False)
+            if not results or not results.get("entries"):
+                return None
+            first = results["entries"][0]
+            video_id = first.get("id")
+            if not video_id:
+                return None
+            info = ydl.extract_info(f"https://www.youtube.com/watch?v={video_id}", download=False)
+        return info
+
+
+def _pick_audio_url(info: dict) -> str | None:
+    if info.get("url"):
+        return info["url"]
+    formats = info.get("formats") or []
+    best = None
+    for fmt in formats:
+        if fmt.get("acodec") and fmt["acodec"] != "none" and fmt.get("url"):
+            if not best or fmt.get("abr", 0) > best.get("abr", 0):
+                best = fmt
+    return best["url"] if best else None
+
+
+@trace_function
+async def build_entry(query: str, requested_by: int) -> QueueEntry | None:
+    info = await asyncio.to_thread(_yt_extract, query)
+    if not info:
+        return None
+    audio_url = _pick_audio_url(info)
+    if not audio_url:
+        return None
+    return QueueEntry(
+        title=info.get("title", "Unknown"),
+        audio_url=audio_url,
+        webpage_url=info.get("webpage_url", ""),
+        requested_by=requested_by,
+        duration=info.get("duration"),
+    )
+
+
+@trace_function
+async def enqueue(guild: discord.Guild, voice_channel: discord.VoiceChannel, entry: QueueEntry) -> int:
+    """Append entry to guild's queue; start player loop if not running.
+    Returns the queue position (0 = playing now / next up)."""
+    gid = guild.id
+    queue = _queues.setdefault(gid, [])
+    queue.append(entry)
+    position = len(queue) - 1 + (1 if gid in _now_playing else 0)
+
+    event = _queue_events.setdefault(gid, asyncio.Event())
+    event.set()
+
+    task = _player_tasks.get(gid)
+    if task is None or task.done():
+        loop = asyncio.get_running_loop()
+        _player_tasks[gid] = loop.create_task(_player_loop(guild, voice_channel))
+
+    return position
+
+
+async def _wait_next(guild_id: int) -> QueueEntry | None:
+    while True:
+        queue = _queues.get(guild_id)
+        if queue:
+            return queue.pop(0)
+        event = _queue_events.setdefault(guild_id, asyncio.Event())
+        event.clear()
+        try:
+            await asyncio.wait_for(event.wait(), timeout=IDLE_DISCONNECT_SECONDS)
+        except asyncio.TimeoutError:
+            return None
+
+
+async def _player_loop(guild: discord.Guild, voice_channel: discord.VoiceChannel):
+    gid = guild.id
+    loop = asyncio.get_running_loop()
+    voice_client = None
+    try:
+        voice_client = guild.voice_client
+        if voice_client is None or not voice_client.is_connected():
+            voice_client = await voice_channel.connect()
+        elif voice_client.channel != voice_channel:
+            await voice_client.move_to(voice_channel)
+
+        while True:
+            entry = await _wait_next(gid)
+            if entry is None:
+                botLogger.info("queue idle timeout for guild %s, disconnecting", gid)
+                break
+
+            _now_playing[gid] = entry
+            done = asyncio.Event()
+
+            def after_playback(error, _done=done, _loop=loop):
+                if error:
+                    botLogger.error("ffmpeg playback failed in queue: %s", error)
+                _loop.call_soon_threadsafe(_done.set)
+
+            source = FFmpegPCMAudio(
+                entry.audio_url,
+                before_options="-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
+                options="-vn",
+            )
+
+            try:
+                voice_client.play(source, after=after_playback)
+            except discord.ClientException as e:
+                botLogger.warning("voice_client.play raised: %s", e)
+                _now_playing.pop(gid, None)
+                continue
+
+            await done.wait()
+            _now_playing.pop(gid, None)
+    except Exception as e:
+        botLogger.error("player loop crashed for guild %s: %s", gid, e, exc_info=True)
+    finally:
+        if voice_client and voice_client.is_connected():
+            try:
+                await voice_client.disconnect()
+            except Exception as e:
+                botLogger.warning("voice disconnect on player loop exit failed: %s", e)
+        _player_tasks.pop(gid, None)
+        _now_playing.pop(gid, None)
+        _queues.pop(gid, None)
+        _queue_events.pop(gid, None)
+
+
+@trace_function
+def skip(guild: discord.Guild) -> bool:
+    vc = guild.voice_client
+    if vc and (vc.is_playing() or vc.is_paused()):
+        vc.stop()
+        return True
+    return False
+
+
+@trace_function
+def get_queue(guild: discord.Guild) -> list[QueueEntry]:
+    return list(_queues.get(guild.id, []))
+
+
+@trace_function
+def get_now_playing(guild: discord.Guild) -> QueueEntry | None:
+    return _now_playing.get(guild.id)
+
+
+@trace_function
+async def stop_and_clear(guild: discord.Guild) -> None:
+    """Hard-stop: clear queue, cancel player task, disconnect."""
+    gid = guild.id
+    _queues.pop(gid, None)
+    _now_playing.pop(gid, None)
+    event = _queue_events.get(gid)
+    if event:
+        event.set()
+    task = _player_tasks.get(gid)
+    if task and not task.done():
+        task.cancel()
+    vc = guild.voice_client
+    if vc and vc.is_connected():
+        if vc.is_playing() or vc.is_paused():
+            vc.stop()
+        try:
+            await vc.disconnect()
+        except Exception as e:
+            botLogger.warning("stop_and_clear disconnect failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Slash command handlers (used by bot.py in Phase 4)
+# ---------------------------------------------------------------------------
+
+@trace_function
+async def queue_play(interaction: discord.Interaction, query: str):
+    await interaction.response.defer()
+    if not query:
+        await interaction.followup.send(
+            embed=make_embed("❌ Please provide a URL or search query.", kind="error")
+        )
+        return
+
+    voice_channel = interaction.user.voice.channel if interaction.user.voice else None
+    if not voice_channel:
+        await interaction.followup.send(
+            embed=make_embed("❌ You need to join a voice channel first!", kind="error")
+        )
+        return
+
+    entry = await build_entry(query, interaction.user.id)
+    if entry is None:
+        await interaction.followup.send(
+            embed=make_embed("❌ Could not find audio for that query.", kind="error")
+        )
+        return
+
+    position = await enqueue(interaction.guild, voice_channel, entry)
+    if position <= 0:
+        msg = f"🎵 Now playing: **{entry.title}**"
+    else:
+        msg = f"➕ Queued **{entry.title}** (position {position})"
+    await interaction.followup.send(embed=make_embed(msg, kind="success"))
+
+
+@trace_function
+async def skip_track(interaction: discord.Interaction):
+    if skip(interaction.guild):
+        await interaction.response.send_message(
+            embed=make_embed("⏭️ Skipped.", kind="success")
+        )
+    else:
+        await interaction.response.send_message(
+            embed=make_embed("Nothing is playing.", kind="info")
+        )
+
+
+@trace_function
+async def queue_show(interaction: discord.Interaction):
+    np = get_now_playing(interaction.guild)
+    upcoming = get_queue(interaction.guild)
+    if not np and not upcoming:
+        await interaction.response.send_message(
+            embed=make_embed("Queue is empty.", kind="info")
+        )
+        return
+    lines: list[str] = []
+    if np:
+        lines.append(f"**Now playing:** {np.title}")
+    if upcoming:
+        lines.append("")
+        lines.append("**Up next:**")
+        for i, e in enumerate(upcoming[:20], start=1):
+            lines.append(f"`{i}.` {e.title}")
+        if len(upcoming) > 20:
+            lines.append(f"_…and {len(upcoming) - 20} more_")
+    await interaction.response.send_message(
+        embed=make_embed("\n".join(lines), kind="info", title="🎶 Queue")
+    )
+
+
+@trace_function
+async def now_playing(interaction: discord.Interaction):
+    np = get_now_playing(interaction.guild)
+    if not np:
+        await interaction.response.send_message(
+            embed=make_embed("Nothing is playing.", kind="info")
+        )
+        return
+    desc = f"**{np.title}**"
+    if np.webpage_url:
+        desc += f"\n{np.webpage_url}"
+    await interaction.response.send_message(
+        embed=make_embed(desc, kind="info", title="▶️ Now playing")
+    )
+
+
+@trace_function
+async def op_play(interaction: discord.Interaction, anime: str):
+    if not anime:
+        await interaction.response.send_message(
+            embed=make_embed("❌ Please name an anime.", kind="error")
+        )
+        return
+    await queue_play(interaction, f"{anime} opening")


### PR DESCRIPTION
## Summary
Per-guild music queue alongside the existing one-shot `/play`. Five new slash commands, all in `functions/queue.py` with module-level per-guild state.

- `/queue_play <query>` — enqueue a YouTube URL or search term. Starts playing immediately if nothing is queued; otherwise appends.
- `/skip` — stop the current track; the player loop advances to the next one.
- `/queue` — numbered list of upcoming tracks (plus the now-playing entry).
- `/now_playing` — current entry with its webpage URL.
- `/op <anime>` — synthesises `f"{anime} opening"` and queues the first YouTube hit.

Existing `/play` stays unchanged (its yt-dlp extraction snippet is duplicated in `queue.py` so the two paths can't interfere).

Player loop disconnects after 5 minutes of queue idleness.

## Test plan
- [ ] Join a voice channel.
- [ ] `/queue_play query: vinland saga op 1` — bot joins, embed `🎵 Now playing: ...`.
- [ ] `/queue_play query: <another song>` — embed `➕ Queued **X** (position 1)`.
- [ ] `/queue` — shows now-playing + one entry in the list.
- [ ] `/now_playing` — current track embed with URL.
- [ ] `/skip` — advances to the queued track; `/now_playing` reflects the new one.
- [ ] `/op anime: vinland saga` — queues the opening; `/queue` lists it.
- [ ] Let the queue drain, wait ~5 min — bot disconnects from voice on its own.
- [ ] `/skip` when nothing is playing → ephemeral-ish info embed `Nothing is playing.`
- [ ] `/queue_play` without being in a voice channel yourself → `❌ You need to join a voice channel first!`
- [ ] Regression: `/play` still works exactly as before, and `/leave` still disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)