### PR TITLE
feat(tasks): MAL snapshot refresh + weekly leaderboard + milestones

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,10 @@ from functions.mal import (
     next_episode, mal_compare, mal_stats, anime_recommend, who_is_watching,
 )
 from functions.season import season_anime
-from functions.tasks import _run_new_episode_check_logic, check_for_new_anime
+from functions.tasks import (
+    _run_new_episode_check_logic, check_for_new_anime,
+    refresh_all_mal_snapshots, weekly_leaderboard,
+)
 from utils.db import episode_announcement_get_series, rss_subscribe
 from config.consts import OTAKU_CHANNEL_ID
 
@@ -86,6 +89,8 @@ async def on_ready():
         print('tasks running.')
         check_for_new_anime.start(bot)
         _run_new_episode_check_logic.start(bot)
+        refresh_all_mal_snapshots.start(bot)
+        weekly_leaderboard.start(bot)
 
 
 @bot.event

--- a/functions/mal.py
+++ b/functions/mal.py
@@ -112,16 +112,17 @@ SNAPSHOT_STALE_SECONDS = 6 * 60 * 60
 
 
 @trace_function
-async def _refresh_user_snapshot(username: str) -> int:
+async def _refresh_user_snapshot(username: str) -> list[dict]:
     """Pull `username`'s full MAL list, replace their snapshot, write activity
-    rows for the diff. Returns the entry count fetched (0 = list private/empty)."""
+    rows for the diff. Returns the diff rows (empty if list private/empty or
+    nothing changed). Callers that just want freshness can ignore the return."""
     entries = await anime_api.get_user_list(username)
     if not entries:
-        return 0
+        return []
     diff = await mal_snapshot_replace(username, entries)
     if diff:
         await mal_activity_record([dict(d, username=username) for d in diff])
-    return len(entries)
+    return diff
 
 
 @trace_function

--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -4,9 +4,11 @@ from utils.tracing import trace_function
 from utils.db import (
     rss_get_all_episodes, rss_update_episode, rss_add_feed, rss_get_series_list,
     episode_announcement_record,
+    mal_get_users, mal_get_discord_for_username,
+    mal_activity_episodes_by_month, mal_activity_leaderboard, mal_alltime_leader,
 )
 from fuzzywuzzy import fuzz
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from discord.ext import tasks
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -141,6 +143,114 @@ def vector_similarity(str1, str2):
 @trace_function
 def string_similar(str1, str2):
     return fuzz_similarity(str1, str2) > 0.85 or vector_similarity(str1, str2) > 0.37
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: per-user snapshot refresh + leaderboard + milestone announcements
+# ---------------------------------------------------------------------------
+
+MONTHLY_EPISODES_MILESTONE = 100
+
+
+async def _user_mention_or_name(username: str) -> str:
+    discord_id = await mal_get_discord_for_username(username)
+    return f"<@{discord_id}>" if discord_id else f"**{username}**"
+
+
+async def _monthly_total(username: str) -> int:
+    months = await mal_activity_episodes_by_month(username, months=1)
+    return sum(v for _, v in months) if months else 0
+
+
+@tasks.loop(hours=6)
+@trace_function
+async def refresh_all_mal_snapshots(bot):
+    """Refresh every linked user's MAL snapshot and emit milestone announcements
+    from each diff. Runs every 6h."""
+    # Lazy import — functions/mal.py imports from this module, so a top-level
+    # import would be circular.
+    from functions.mal import _refresh_user_snapshot
+
+    channel = bot.get_channel(OTAKU_CHANNEL_ID)
+    users = await mal_get_users()
+    botLogger.info("refresh_all_mal_snapshots: %d users", len(users))
+
+    for username in users:
+        try:
+            prev_monthly = await _monthly_total(username)
+            diff = await _refresh_user_snapshot(username)
+            if not diff:
+                continue
+            new_monthly = await _monthly_total(username)
+            mention = await _user_mention_or_name(username)
+
+            if channel is not None:
+                for d in diff:
+                    if d.get("new_status") == Statuses.COMPLETED.value:
+                        await channel.send(
+                            embed=make_embed(
+                                f"🎉 {mention} finished **{d['title']}**!",
+                                kind="success",
+                            )
+                        )
+
+                if prev_monthly < MONTHLY_EPISODES_MILESTONE <= new_monthly:
+                    await channel.send(
+                        embed=make_embed(
+                            f"🔥 {mention} just hit **{new_monthly}** episodes this month!",
+                            kind="success",
+                        )
+                    )
+        except Exception as e:
+            botLogger.error(
+                "refresh_all_mal_snapshots failed for %s: %s",
+                username, e, exc_info=True,
+            )
+
+    botLogger.info("refresh_all_mal_snapshots: done")
+
+
+@tasks.loop(hours=168)
+@trace_function
+async def weekly_leaderboard(bot):
+    """Post a weekly podium of top episode-watchers + an all-time leader footer."""
+    channel = bot.get_channel(OTAKU_CHANNEL_ID)
+    if channel is None:
+        botLogger.warning("weekly_leaderboard: OTAKU channel not found")
+        return
+
+    week_ago = datetime.now(tz=timezone.utc) - timedelta(days=7)
+    top = await mal_activity_leaderboard(since=week_ago)
+
+    if not top:
+        await channel.send(
+            embed=make_embed(
+                "📊 No tracked MAL activity this week.",
+                kind="info",
+                title="Weekly anime leaderboard",
+            )
+        )
+        return
+
+    medals = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
+    lines: list[str] = []
+    for i, (username, total) in enumerate(top[:5]):
+        mention = await _user_mention_or_name(username)
+        lines.append(f"{medals[i]} {mention} — **{total}** episodes")
+
+    alltime = await mal_alltime_leader()
+    if alltime:
+        alltime_mention = await _user_mention_or_name(alltime[0])
+        lines.append("")
+        lines.append(f"_All-time leader: {alltime_mention} with **{alltime[1]:,}** episodes_")
+
+    await channel.send(
+        embed=make_embed(
+            "\n".join(lines),
+            kind="info",
+            title="📊 Weekly anime leaderboard",
+        )
+    )
 
 
 


### PR DESCRIPTION
## Summary
Two new `discord.ext.tasks` loops gated by `config.debug`, started from `on_ready` alongside the existing RSS/MAL background work.

**`refresh_all_mal_snapshots` (every 6h)**
- For each `mal_profiles` row, calls `_refresh_user_snapshot` (now returns the diff).
- Emits milestones to `OTAKU_CHANNEL_ID`:
  - `🎉 <user> finished **<title>**!` for every diff row with `new_status == COMPLETED`.
  - `🔥 <user> just hit N episodes this month!` if the user crossed the 100-eps/30d threshold on this run (prev<100 ∧ new≥100).
- Per-user errors are caught + logged; one bad user doesn't kill the loop.

**`weekly_leaderboard` (every 168h)**
- Top 5 weekly watchers from `mal_activity_leaderboard(since=now-7d)` as a podium embed (🥇🥈🥉 4️⃣ 5️⃣).
- Footer line with all-time leader from `mal_alltime_leader()`.
- Posts a neutral "no activity this week" embed if nothing tracked.

Both resolve MAL usernames → Discord `<@id>` mentions where linked, otherwise `**username**`.

**Minor refactor:** `_refresh_user_snapshot` now returns `list[dict]` (the diff) instead of `int` (entry count). The diff was already being computed for `mal_activity` writes; it just wasn't surfaced. Only existing caller (`_refresh_if_stale`) was discarding the return value, so no other code change needed. The `tasks.py → mal.py` import is done lazily inside the task body to avoid a circular import.

## Test plan
Tasks fire once immediately on `.start()`, so a `docker compose restart bot` triggers the first run within seconds (provided `config.debug` is false).

- [ ] `docker compose up -d --build` → `docker compose logs -f bot` shows `tasks running.` then `refresh_all_mal_snapshots: N users` then `refresh_all_mal_snapshots: done` within ~30s.
- [ ] Within ~10s after, OTAKU channel may get a "weekly leaderboard" embed (depends on whether anyone's accumulated 7d activity).
- [ ] To force a completion milestone: mark something as Completed on your MAL → wait for next refresh (or restart bot) → expect `🎉 ... finished **X**!` post.
- [ ] To force a monthly milestone: needs >=100 episodes/month delta. Hard to fake; trust the SQL: `SELECT username, SUM(delta_episodes) FROM mal_activity WHERE recorded_at >= NOW() - INTERVAL '30 days' GROUP BY username;` should match what the threshold check sees.
- [ ] Regression: `/mal_link`, `/mal_compare`, `/mal_stats`, `/anime_recommend`, `/who_is_watching`, `/next_episode`, `/season_anime` all still work (they share the snapshot pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)