### PR TITLE
fix(mal): coerce numeric anime titles to str (e.g. "86")

### DIFF
--- a/utils/anime_api.py
+++ b/utils/anime_api.py
@@ -224,7 +224,10 @@ async def get_user_list(username: str, status: int | None = None) -> list[dict]:
                 score = entry.get("score")
                 results.append({
                     "mal_id":           int(mal_id),
-                    "title":            title,
+                    # MAL serialises numeric-looking titles as JSON numbers
+                    # (e.g. the anime "86"). Force a string here so downstream
+                    # asyncpg INSERTs against a TEXT column don't blow up.
+                    "title":            str(title),
                     "status":           int(normalized_status),
                     "score":            int(score) if score else None,
                     "episodes_watched": int(entry.get("num_watched_episodes") or 0),

--- a/utils/db.py
+++ b/utils/db.py
@@ -492,7 +492,7 @@ async def mal_snapshot_replace(username: str, entries: list[dict]) -> list[dict]
                         (
                             username,
                             int(e["mal_id"]),
-                            e["title"],
+                            str(e["title"]),
                             int(e["status"]),
                             int(e["score"]) if e.get("score") else None,
                             int(e.get("episodes_watched") or 0),


### PR DESCRIPTION
## Summary
Production logs from `refresh_all_mal_snapshots`:
```
asyncpg.exceptions.DataError: invalid input for query argument $3 in element
#641 of executemany() sequence: 86 (expected str, got int)
refresh_all_mal_snapshots failed for uriel0777
```

The user `uriel0777` has the anime **"86" (Eighty Six)** on their list. MAL's internal `load.json` serialises that title as a JSON number, not a string — Python parses it as `int`, asyncpg refuses to write it to `mal_list_snapshots.title` (TEXT NOT NULL).

Fixed at two layers:
- `utils/anime_api.py:get_user_list` — `str()` the title at the API boundary so every downstream caller gets a string.
- `utils/db.py:mal_snapshot_replace` — also `str()` at the DB write site as belt-and-suspenders.

The bug was silent until the Phase 5 refresh task iterated every linked user. The original Phase 1 smoke account (Stark700) didn't have an "86"-style title, so it shipped to production undetected.

## Test plan
- [ ] Merge + redeploy. Watch logs for the next `refresh_all_mal_snapshots` run (fires within ~30s of restart).
- [ ] Expect `refresh_all_mal_snapshots: done` with **no** asyncpg DataError for `uriel0777`.
- [ ] `psql`: `SELECT * FROM mal_list_snapshots WHERE username='uriel0777' AND title='86';` should return a row.
- [ ] `/who_is_watching anime: 86` should now resolve, and pick up uriel0777 if they're currently watching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)