### PR TITLE
fix(tasks): suppress milestone storm on a user's first snapshot ingest

### DIFF
--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -4,7 +4,7 @@ from utils.tracing import trace_function
 from utils.db import (
     rss_get_all_episodes, rss_update_episode, rss_add_feed, rss_get_series_list,
     episode_announcement_record,
-    mal_get_users, mal_get_discord_for_username,
+    mal_get_users, mal_get_discord_for_username, mal_snapshot_get,
     mal_activity_episodes_by_month, mal_activity_leaderboard, mal_alltime_leader,
 )
 from fuzzywuzzy import fuzz
@@ -177,10 +177,27 @@ async def refresh_all_mal_snapshots(bot):
 
     for username in users:
         try:
-            prev_monthly = await _monthly_total(username)
+            # First-ingest guard: if we have no snapshot for this user yet, the
+            # diff returned by _refresh_user_snapshot below treats every entry
+            # as a status change (mal_id not in old → status_changed=True),
+            # which would fire a milestone for every completed anime they own.
+            # Skip milestone emission on the run that populates the snapshot.
+            prior_snapshot = await mal_snapshot_get(username)
+            is_first_ingest = not prior_snapshot
+
+            prev_monthly = 0 if is_first_ingest else await _monthly_total(username)
             diff = await _refresh_user_snapshot(username)
             if not diff:
                 continue
+
+            if is_first_ingest:
+                botLogger.info(
+                    "refresh_all_mal_snapshots: first ingest for %s, "
+                    "suppressing %d milestone events",
+                    username, len(diff),
+                )
+                continue
+
             new_monthly = await _monthly_total(username)
             mention = await _user_mention_or_name(username)
 


### PR DESCRIPTION
## The bug
After #85 fixed the \"86\" numeric-title crash, the next \`refresh_all_mal_snapshots\` for affected users (e.g. \`uriel0777\`) flooded OTAKU with one \`🎉 <user> finished **<title>**!\` message per completed anime they own — hundreds of notifications in a single tick.

## Why
\`mal_snapshot_replace\` computes its diff by comparing each new entry against the prior snapshot. When the prior snapshot is **empty**, every entry hits the \`mal_id not in old\` branch which sets \`status_changed = True\` and propagates the current status to the diff's \`new_status\` field. The milestone emitter in \`refresh_all_mal_snapshots\` then fires on every \`new_status == COMPLETED\` row.

Same thing happens to the 100-episodes/month milestone: the first ingest writes a huge \`delta_episodes\` covering everything the user has ever watched, instantly crossing the threshold.

It was latent until #85. Before that, every refresh for \`uriel0777\` (and anyone else with the anime \"86\") rolled back transparently, so the snapshot stayed empty. The first successful refresh then dumped every completion to OTAKU.

## Fix
Before iterating the diff for milestones, check whether the user had any prior \`mal_list_snapshots\` rows. If not, log a \"first ingest\" line and skip milestone emission for that user this run. The activity rows still get written — only the channel notifications are suppressed.

## Test plan
- [ ] Pick a user in \`mal_profiles\` who has no snapshot yet: \`DELETE FROM mal_list_snapshots WHERE username = 'test_user';\` (or use a brand-new \`/mal\` add_user)
- [ ] Restart bot → \`refresh_all_mal_snapshots\` fires on start
- [ ] Logs show \`refresh_all_mal_snapshots: first ingest for test_user, suppressing N milestone events\`
- [ ] **No** channel posts for that user this run
- [ ] On the **second** refresh (or another bot restart after the snapshot exists), milestones fire **only** for genuine new completions / threshold crossings

🤖 Generated with [Claude Code](https://claude.com/claude-code)