### PR TITLE
fix(mal): skip mal_activity writes on a user's first snapshot ingest

### DIFF
--- a/functions/mal.py
+++ b/functions/mal.py
@@ -113,14 +113,25 @@ SNAPSHOT_STALE_SECONDS = 6 * 60 * 60
 
 @trace_function
 async def _refresh_user_snapshot(username: str) -> list[dict]:
-    """Pull `username`'s full MAL list, replace their snapshot, write activity
-    rows for the diff. Returns the diff rows (empty if list private/empty or
-    nothing changed). Callers that just want freshness can ignore the return."""
+    """Pull `username`'s full MAL list, replace their snapshot, and write
+    activity rows for the diff — but ONLY when there was a prior snapshot.
+
+    On the first ingest for a user, mal_snapshot_replace produces fake diffs
+    (delta_episodes = total episodes ever watched per anime, new_status set
+    for everything). Writing those to mal_activity would pollute the weekly
+    leaderboard and /mal_stats with a one-time burst that equals the user's
+    all-time totals. We populate the snapshot but skip the activity dump.
+
+    Returns the diff rows so callers can still inspect them — milestone
+    emitters separately gate on a `is_first_ingest` flag (see
+    refresh_all_mal_snapshots) so spurious new_status=COMPLETED rows from
+    first ingest don't trigger announcements either."""
     entries = await anime_api.get_user_list(username)
     if not entries:
         return []
+    prior_existed = bool(await mal_snapshot_updated_at(username))
     diff = await mal_snapshot_replace(username, entries)
-    if diff:
+    if diff and prior_existed:
         await mal_activity_record([dict(d, username=username) for d in diff])
     return diff
 
@@ -178,9 +189,11 @@ async def mal_link(interaction: discord.Interaction, mal_username: str):
         )
         return
 
-    diff = await mal_snapshot_replace(mal_username, entries)
-    if diff:
-        await mal_activity_record([dict(d, username=mal_username) for d in diff])
+    # First ingest by definition — don't write activity rows. The initial
+    # diff's delta_episodes equals each anime's total episodes_watched, which
+    # would otherwise pollute the weekly leaderboard with a one-off burst
+    # equal to the user's all-time totals.
+    await mal_snapshot_replace(mal_username, entries)
 
     await interaction.followup.send(
         embed=make_embed(


### PR DESCRIPTION
## Why
Weekly leaderboard's per-user 7-day total was equal to each user's all-time episode count. Not a MAL quirk — a bug in how we record activity.

\`mal_snapshot_replace\` diffs new entries against the prior snapshot. On a first ingest the prior snapshot is empty, every entry hits the \`mal_id not in old\` branch, and \`delta_episodes\` ends up equal to \`total_episodes_watched\` for that anime. Writing those rows to \`mal_activity\` turns the first-week leaderboard into a mirror of \`mal_alltime_leader\`.

## Fix
Two call sites stop writing activity on a first ingest. Snapshot is still populated, so /mal_compare, /mal_stats score-distribution, /who_is_watching etc. all still work — only the activity log is gated.

- **\`_refresh_user_snapshot\`** — checks \`mal_snapshot_updated_at(username)\` before \`mal_snapshot_replace\`. If \`None\`, skips the \`mal_activity_record\` call. Still returns the diff so the milestone emitter can inspect it (and skip via the existing \`is_first_ingest\` guard in \`refresh_all_mal_snapshots\`).
- **\`mal_link\`** — always a first ingest by definition, so it no longer writes activity rows either.

Going forward, \`mal_activity\` only contains real episode/status deltas between consecutive refreshes — exactly what \`/mal_stats\` and the weekly leaderboard want to count.

## Cleanup for existing polluted data
After merging, run:
\`\`\`sql
TRUNCATE TABLE mal_activity;
\`\`\`
Snapshot is unaffected. Real activity rebuilds naturally on the next refresh ticks as users actually watch episodes.

## Test plan
- [ ] Merge + redeploy.
- [ ] \`docker compose exec db psql -U botuser -d discordbot -c "TRUNCATE TABLE mal_activity;"\`.
- [ ] Force a refresh by restarting the bot (or wait 6h). For users with snapshots, no new \`mal_activity\` rows yet (nothing changed since last refresh).
- [ ] Watch a few episodes on MAL, wait for next refresh tick → \`SELECT * FROM mal_activity WHERE username='Nerd_From_Hell' ORDER BY recorded_at DESC LIMIT 5;\` shows just those new deltas.
- [ ] Run \`/mal_link\` with a fresh test account → \`SELECT count(*) FROM mal_activity WHERE username='<test>';\` returns 0 immediately after.
- [ ] Wait for the next weekly leaderboard (or set the loop to seconds=30 temporarily) → weekly numbers reflect only real recent activity; all-time footer is meaningfully different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)