### PR TITLE
fix(tasks): keep all-time leader on the weekly leaderboard when the week is empty

### DIFF
--- a/functions/tasks.py
+++ b/functions/tasks.py
@@ -238,24 +238,17 @@ async def weekly_leaderboard(bot):
 
     week_ago = datetime.now(tz=timezone.utc) - timedelta(days=7)
     top = await mal_activity_leaderboard(since=week_ago)
-
-    if not top:
-        await channel.send(
-            embed=make_embed(
-                "📊 No tracked MAL activity this week.",
-                kind="info",
-                title="Weekly anime leaderboard",
-            )
-        )
-        return
+    alltime = await mal_alltime_leader()
 
     medals = ["🥇", "🥈", "🥉", "4️⃣", "5️⃣"]
     lines: list[str] = []
-    for i, (username, total) in enumerate(top[:5]):
-        mention = await _user_mention_or_name(username)
-        lines.append(f"{medals[i]} {mention} — **{total}** episodes")
+    if top:
+        for i, (username, total) in enumerate(top[:5]):
+            mention = await _user_mention_or_name(username)
+            lines.append(f"{medals[i]} {mention} — **{total}** episodes")
+    else:
+        lines.append("_No tracked MAL activity this week._")
 
-    alltime = await mal_alltime_leader()
     if alltime:
         alltime_mention = await _user_mention_or_name(alltime[0])
         lines.append("")


### PR DESCRIPTION
## What broke
After truncating `mal_activity` (cleanup from #88), the next weekly leaderboard post lost the all-time leader line:

> 📊 No tracked MAL activity this week.

But the snapshot is intact and the all-time leader query reads from snapshots, so it should still render.

## Why
`weekly_leaderboard` early-returned when `mal_activity_leaderboard(since=now-7d)` was empty, skipping the all-time footer entirely. The two queries hit different sources — weekly from `mal_activity`, all-time from `mal_list_snapshots` — but the function treated them as a single flow.

## Fix
Compute both up-front, then build lines:
- If there's weekly activity → podium.
- If not → one-line "No tracked MAL activity this week".
- Always append the all-time footer when `mal_alltime_leader()` returns something.

## Test plan
- [ ] Merge + redeploy.
- [ ] Restart bot (forces an immediate `weekly_leaderboard` fire).
- [ ] Expect a post in OTAKU with `_No tracked MAL activity this week._` on top and `_All-time leader: @NerdFromHell with **16,420** episodes_` underneath.
- [ ] After enough real activity accumulates, future weeks render the podium *and* the all-time footer together (as before).

User does not need to relink — their snapshot is intact, this was a render-path bug only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)