### PR TITLE
feat(bot): /help — list all commands grouped by feature

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,6 +23,7 @@ from functions.mal import (
 )
 from functions.season import season_anime
 from functions.quiz import anime_quiz
+from functions.help import show_help
 from functions.tasks import (
     _run_new_episode_check_logic, check_for_new_anime,
     refresh_all_mal_snapshots, weekly_leaderboard,
@@ -353,6 +354,16 @@ async def season_anime_command(interaction: discord.Interaction):
 async def anime_quiz_command(interaction: discord.Interaction):
     botLogger.info('run anime_quiz_command')
     await anime_quiz(interaction)
+
+#endregion
+
+#region Help
+
+@bot.tree.command(name="help", description="List every command the bot exposes, grouped by feature")
+@trace_function
+async def help_command(interaction: discord.Interaction):
+    botLogger.info('run help_command')
+    await show_help(interaction)
 
 #endregion
 

--- a/functions/help.py
+++ b/functions/help.py
@@ -1,0 +1,70 @@
+import discord
+
+from utils.tracing import trace_function
+from utils.utils import make_embed
+
+# Maps command name -> category label. Commands without an entry fall into
+# the "Other" group as a soft reminder to register them here.
+CATEGORIES: dict[str, str] = {
+    "roulette":         "🎲 Roulette",
+    "auto_roulette":    "🎲 Roulette",
+
+    "play":             "🎵 Music",
+    "queue_play":       "🎵 Music",
+    "skip":             "🎵 Music",
+    "queue":            "🎵 Music",
+    "now_playing":      "🎵 Music",
+    "op":               "🎵 Music",
+    "leave":            "🎵 Music",
+
+    "mal":              "📺 Anime / MAL",
+    "anime_list":       "📺 Anime / MAL",
+    "next_anime":       "📺 Anime / MAL",
+    "mal_link":         "📺 Anime / MAL",
+    "next_episode":     "📺 Anime / MAL",
+    "mal_compare":      "📺 Anime / MAL",
+    "mal_stats":        "📺 Anime / MAL",
+    "anime_recommend":  "📺 Anime / MAL",
+    "who_is_watching":  "📺 Anime / MAL",
+
+    "rss":              "📡 RSS / torrents",
+    "nyaa":             "📡 RSS / torrents",
+
+    "season_anime":     "✨ Discovery",
+    "anime_quiz":       "✨ Discovery",
+
+    "help":             "ℹ️ Meta",
+}
+
+CATEGORY_ORDER = [
+    "📺 Anime / MAL",
+    "✨ Discovery",
+    "📡 RSS / torrents",
+    "🎵 Music",
+    "🎲 Roulette",
+    "ℹ️ Meta",
+    "Other",
+]
+
+
+@trace_function
+async def show_help(interaction: discord.Interaction):
+    tree = interaction.client.tree
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    for cmd in tree.get_commands():
+        category = CATEGORIES.get(cmd.name, "Other")
+        grouped.setdefault(category, []).append((cmd.name, cmd.description or ""))
+
+    lines: list[str] = []
+    for category in CATEGORY_ORDER:
+        cmds = grouped.get(category)
+        if not cmds:
+            continue
+        lines.append(f"**{category}**")
+        for name, desc in sorted(cmds):
+            lines.append(f"`/{name}` — {desc}" if desc else f"`/{name}`")
+        lines.append("")
+
+    embed = make_embed("\n".join(lines).rstrip(), kind="info", title="🤖 Bot commands")
+    embed.set_footer(text="Slash commands work in any channel the bot can see.")
+    await interaction.response.send_message(embed=embed, ephemeral=True)


### PR DESCRIPTION
## Summary
New `/help` slash command. Single ephemeral embed listing every registered command, grouped into Anime/MAL, Discovery, RSS/torrents, Music, Roulette, Meta, and a fallback Other bucket.

- `functions/help.py:show_help` walks `interaction.client.tree.get_commands()` at request time so the listing is always in sync with what Discord actually has registered. No drift risk on descriptions.
- Static `CATEGORIES` map slots known command names into the right group; anything new and unmapped falls into "Other" as a soft reminder to update the map.
- Ephemeral reply, no defer (in-memory data).

## Test plan
- [ ] `docker compose up -d --build`. Wait up to ~2 min for Discord's global command sync.
- [ ] `/help` in any channel — reply visible only to you.
- [ ] All 22 existing commands + `/help` itself appear in the embed, grouped under the expected categories. "Other" group should be empty.
- [ ] Categories render in the order from `CATEGORY_ORDER` (Anime/MAL first, then Discovery, RSS/torrents, Music, Roulette, Meta).
- [ ] Regression: every existing command still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)