### PR TITLE
feat(mal): /mal_unlink — drop the Discord <-> MAL binding

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,7 @@ from functions.queue import queue_play, skip_track, queue_show, now_playing, op_
 from functions.feed import rss_menu
 from functions.nyaa import search
 from functions.mal import (
-    mal_menu, anime_list_menu, next_anime, mal_link,
+    mal_menu, anime_list_menu, next_anime, mal_link, mal_unlink,
     next_episode, mal_compare, mal_stats, anime_recommend, who_is_watching,
 )
 from functions.season import season_anime
@@ -301,6 +301,12 @@ async def next_anime_command(interaction: discord.Interaction):
 async def mal_link_command(interaction: discord.Interaction, mal_username: str):
     botLogger.info('run mal_link_command')
     await mal_link(interaction, mal_username)
+
+@bot.tree.command(name="mal_unlink", description="Remove the link between your Discord and your MAL username")
+@trace_function
+async def mal_unlink_command(interaction: discord.Interaction):
+    botLogger.info('run mal_unlink_command')
+    await mal_unlink(interaction)
 
 @bot.tree.command(name="next_episode", description="Countdown until an anime's next episode")
 @app_commands.describe(anime="Anime title to search for")

--- a/functions/help.py
+++ b/functions/help.py
@@ -21,6 +21,7 @@ CATEGORIES: dict[str, str] = {
     "anime_list":       "📺 Anime / MAL",
     "next_anime":       "📺 Anime / MAL",
     "mal_link":         "📺 Anime / MAL",
+    "mal_unlink":       "📺 Anime / MAL",
     "next_episode":     "📺 Anime / MAL",
     "mal_compare":      "📺 Anime / MAL",
     "mal_stats":        "📺 Anime / MAL",

--- a/functions/mal.py
+++ b/functions/mal.py
@@ -9,7 +9,8 @@ from utils.utils import *
 from utils.tracing import trace_function
 from utils.db import (
     mal_get_users, mal_add_user, mal_remove_user, anime_list_get,
-    mal_link_discord, mal_get_username_for_discord, mal_get_discord_for_username,
+    mal_link_discord, mal_unlink_discord,
+    mal_get_username_for_discord, mal_get_discord_for_username,
     mal_snapshot_replace, mal_snapshot_get, mal_snapshot_updated_at,
     mal_activity_record, mal_activity_episodes_by_month, mal_score_distribution,
     mal_who_has,
@@ -198,6 +199,30 @@ async def mal_link(interaction: discord.Interaction, mal_username: str):
     await interaction.followup.send(
         embed=make_embed(
             f"✅ Linked to **{mal_username}** — {len(entries)} entries cached.",
+            kind="success",
+        ),
+        ephemeral=True,
+    )
+
+
+@trace_function
+async def mal_unlink(interaction: discord.Interaction):
+    await interaction.response.defer(ephemeral=True)
+    unlinked = await mal_unlink_discord(interaction.user.id)
+    if unlinked is None:
+        await interaction.followup.send(
+            embed=make_embed(
+                "You don't have a MAL account linked. Use `/mal_link` first.",
+                kind="info",
+            ),
+            ephemeral=True,
+        )
+        return
+    await interaction.followup.send(
+        embed=make_embed(
+            f"🔓 Unlinked **{unlinked}** from your Discord. Your cached list "
+            "data stays for community queries — use `/mal` → Remove user if "
+            "you want it wiped entirely.",
             kind="success",
         ),
         ephemeral=True,

--- a/utils/db.py
+++ b/utils/db.py
@@ -421,6 +421,22 @@ async def mal_link_discord(username: str, discord_user_id: int) -> bool:
 
 
 @trace_function
+async def mal_unlink_discord(discord_user_id: int) -> str | None:
+    """Clear the Discord binding for this user. Returns the MAL username that
+    was bound (so the caller can echo it back), or None if no binding existed."""
+    async with get_pool().acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            UPDATE mal_profiles SET discord_user_id = NULL
+            WHERE discord_user_id = $1
+            RETURNING username
+            """,
+            discord_user_id,
+        )
+    return row["username"] if row else None
+
+
+@trace_function
 async def mal_get_username_for_discord(discord_user_id: int) -> str | None:
     async with get_pool().acquire() as conn:
         row = await conn.fetchrow(


### PR DESCRIPTION
## Summary
Counterpart to `/mal_link`. Clears `mal_profiles.discord_user_id` for the caller so they can re-link to a different MAL username (or just stop being mentioned in community queries).

- `mal_unlink_discord(discord_user_id)` — new DB helper using `UPDATE ... RETURNING` for atomic clear + readback of the prior bound username.
- Snapshot rows (`mal_list_snapshots`) and `mal_activity` are intentionally left alone — `/who_is_watching` and `/mal_compare` (from another user's perspective) still surface the MAL username, just without the Discord mention.
- For full removal, the existing `/mal` → Remove user already cascades through the snapshot FK.

## Test plan
- [ ] `/mal_unlink` when linked → ephemeral `🔓 Unlinked **<your-mal>** from your Discord. Your cached list … stays for community queries — use /mal → Remove user if you want it wiped entirely.`
- [ ] `psql`: `SELECT discord_user_id FROM mal_profiles WHERE username='<your-mal>';` returns `NULL`.
- [ ] Re-run `/mal_unlink` → ephemeral `You don't have a MAL account linked. Use /mal_link first.`
- [ ] Re-run `/mal_link <your-mal>` → re-binds successfully.
- [ ] `/who_is_watching` on something on your list still shows your MAL username (just as plain text instead of a Discord mention while you're unlinked).
- [ ] `/help` lists `mal_unlink` under 📺 Anime / MAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)