### PR TITLE
fix(bot): mark /next_episode anime arg explicitly optional

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -311,7 +311,7 @@ async def mal_unlink_command(interaction: discord.Interaction):
 @bot.tree.command(name="next_episode", description="Next episode for each of your RSS subs (or pass anime: to look up one)")
 @app_commands.describe(anime="Optional: look up a specific anime instead of your subscription list")
 @trace_function
-async def next_episode_command(interaction: discord.Interaction, anime: str = None):
+async def next_episode_command(interaction: discord.Interaction, anime: str | None = None):
     botLogger.info('run next_episode_command')
     await next_episode(interaction, anime)
 


### PR DESCRIPTION
## Why
User reported `/next_episode` still requires the `anime:` field after #93. The signature was `anime: str = None`, which is semantically optional in Python, but discord.py's app_commands introspection is more reliable with the explicit `str | None = None` form (avoids any case where the parameter gets registered as required despite the default).

## Fix
One-character change: `anime: str = None` → `anime: str | None = None`.

## What the user needs to do after this merges + redeploys
1. The bot does `bot.tree.sync()` on startup, which pushes the refreshed schema to Discord.
2. Discord's clients aggressively cache slash-command definitions per guild, so even after sync the user may need to **reload their Discord client** (Ctrl+R on desktop, or fully quit and reopen on mobile) to pick up the new schema.
3. Once reloaded, typing `/next_episode` should let the user submit immediately without filling the `anime:` field. Filling it falls through to the existing single-show search path.

## Test plan
- [ ] Bot redeploys, `bot.tree.sync()` runs.
- [ ] Reload Discord client (Ctrl+R).
- [ ] Type `/next_episode` → submit without `anime:` → batch subscription view appears.
- [ ] Type `/next_episode anime: one piece` → search + picker + single-show countdown still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)