### PR TITLE
chore(deps): bump discord.py to 2.7.1 + add davey (DAVE protocol)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-discord.py==2.6.4
+discord.py==2.7.1
+davey~=0.1.5
 asyncpg~=0.30.0
 yt-dlp # Latest version always
 matplotlib==3.10.8


### PR DESCRIPTION
## Summary
- Bumps `discord.py` from 2.6.4 → 2.7.1 and adds the new `davey~=0.1.5` runtime so the bot can speak Discord's DAVE (audio/video E2EE) protocol, which was globally enforced on 2026-03-02.
- Without this, every voice command (`/play`, `/queue_play`, `/skip`, `/now_playing`, `/op`, `/leave`) is rejected at the voice gateway with WebSocket close code **4017** in a retry loop — see [discord.py PR #10300](https://github.com/Rapptz/discord.py/pull/10300) and [Pycord #3135](https://github.com/Pycord-Development/pycord/issues/3135) for the upstream context.
- Pure dependency bump — no code changes. `functions/queue.py`, `functions/voice.py`, `bot.py`, and the `Dockerfile` are untouched. `davey` publishes manylinux x86_64 wheels, so the slim Debian image picks up a prebuilt wheel and needs no Rust toolchain.

## Test plan
- [x] `python -m pip install discord.py==2.7.1 davey~=0.1.5` resolves to wheels on Windows.
- [x] `python -m discord --version` reports `discord.py v2.7.1-final` and `davey v0.1.5`.
- [ ] `docker compose build bot` succeeds without invoking a Rust compile step (wheel match).
- [ ] In a test guild, join a VC and run `/queue_play <youtube query>` — bot joins, embed posts, audio plays, and `WebSocket closed with 4017` no longer appears in logs.
- [ ] Mid-track `/skip` and `/queue` still behave correctly.
- [ ] Regression: `/play <query>` (legacy single-shot path in `functions/voice.py`) also works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)